### PR TITLE
Update knowrob-base.rosinstall

### DIFF
--- a/rosinstall/knowrob-base.rosinstall
+++ b/rosinstall/knowrob-base.rosinstall
@@ -1,1 +1,2 @@
 - git: {local-name: stacks/knowrob, uri: 'https://github.com/knowrob/knowrob.git'}
+- git: {local-name: rosjava_jni, uri: 'https://github.com/gheorghelisca/rosjava_jni.git'}


### PR DESCRIPTION
Following the base install under ROS Hydro fails because rosjava_jni is not available as debian package. I suggest to include the source repo into the rosinstall-file. This worked smooth for me on Ubuntu 12.04 + ROS Hydro with a mixed rosbuild/catkin workspace.
