### PR TITLE
Update srdl2.pl to allow queries for robots with capabilities

### DIFF
--- a/mod_srdl/prolog/srdl2.pl
+++ b/mod_srdl/prolog/srdl2.pl
@@ -127,8 +127,8 @@ cap_available_on_robot(Cap, Robot) :-
 
 % capability asserted for robot class
 cap_available_on_robot(Cap, Robot) :-
-    rdfs_individual_of(Robot, RobotClass),
     owl_subclass_of(RobotClass, knowrob:'Robot'),
+    rdfs_individual_of(Robot, RobotClass),
     class_properties(RobotClass, srdl2cap:'hasCapability', SubCap),
 
     % If sub-properties are available, their super-capabilites are also


### PR DESCRIPTION
A query like:

 cap_available_on_robot('http://ias.cs.tum.edu/kb/srdl2-cap.owl#GraspingCapability', R).

currently causes a failure because the call "rdfs_individual_of(Robot, RobotClass)" fails with a "not initialized" Exception if no robot is provided in the query. switching the order of the calls solves the problem for me
