### PR TITLE
Make knowrob_vis webserver configurable.

### DIFF
--- a/knowrob_vis/knowrob_vis/src/main/java/org/knowrob/vis/MarkerVisualization.java
+++ b/knowrob_vis/knowrob_vis/src/main/java/org/knowrob/vis/MarkerVisualization.java
@@ -126,7 +126,10 @@ public class MarkerVisualization extends AbstractNodeMain {
 		log = connectedNode.getLog();
 		// Need to start the webserver after node in order to able to use
 		// ROS parameters for server configuration.
-		startWebServer(1111);
+		if(node.getParameterTree().getBoolean("knowrob_vis/webserver_start", true)) {
+			int port = node.getParameterTree().getInteger("knowrob_vis/webserver_port", 1111);
+			startWebServer(port);
+		}
 	}
 	
 	public void setCameraPose(final String[] positions, final String[] orientations) {


### PR DESCRIPTION
When using knowrob_vis, it is not always desirable to launch a webserver on a fixed port.
This makes the startup configurable on the parameter server like in this example launch file exerpt:
```
  <param name="initial_package" type="string" value="knowrob_vis" />
  <param name="initial_goal" type="string" value="visualisation_canvas" />
  <param name="knowrob_vis/webserver_start" type="bool" value="false" />
  <param name="knowrob_vis/webserver_port" type="bool" value="31337" />
  <node name="json_prolog" pkg="json_prolog" type="json_prolog_node" cwd="node" output="screen" />
```