### PR TITLE
Allow various levels of depth for classpath.txt file.

### DIFF
--- a/rosprolog/scripts/get_classpaths
+++ b/rosprolog/scripts/get_classpaths
@@ -6,7 +6,7 @@ output=""
 is_first=1
 for ROS_PATH in `echo $ROS_PACKAGE_PATH | tr ":" "\n"`
 do
-    for CLASS_PATH_FILE in `ls $ROS_PATH/*/*/*/build/classpath.txt 2> /dev/null`; do
+    for CLASS_PATH_FILE in `find $ROS_PATH -path '*/build/classpath.txt' 2> /dev/null`; do
         if [ $is_first -eq 0 ]; then
             output="$output:"
         fi


### PR DESCRIPTION
For **collection of packages** the fixed path depth of the `classpath.txt` file works but when you develop just a **single package** you can expect the path to be one directory shorter e.g. `package_name/component_name/build/classpath.txt`
therefore, you won't have access to your Java classes from JPL in `rosprolog`.

With proposed here fix the path can be of arbitrary depth.