### PR TITLE
Added missing dependency of json_prolog.

### DIFF
--- a/json_prolog/package.xml
+++ b/json_prolog/package.xml
@@ -27,6 +27,7 @@
   <build_depend>json_prolog_msgs</build_depend>
   <build_depend>rosprolog</build_depend>
   <build_depend>knowrob_common</build_depend>
+  <build_depend>libjson-glib</build_depend>
 
   <run_depend>rosprolog</run_depend>
   <run_depend>knowrob_common</run_depend>


### PR DESCRIPTION
I encountered this missing dependency when compiling knowrob from source on a freshly installed Ubuntu 14.04.