### PR TITLE
Fix rosprolog-test: Only run tests for packages specified as arguments.

### DIFF
--- a/rosprolog/scripts/rosprolog-test
+++ b/rosprolog/scripts/rosprolog-test
@@ -20,7 +20,7 @@ if [ -n "$1" ]; then
      fi
      IFS=','
    done
-   SCRIPT_FILE="-g $G_ARGS,load_test_files(_) -t ignore(run_tests),halt"
+   SCRIPT_FILE="-g $G_ARGS,load_test_files(_) -t ignore(run_tests([$1])),halt"
 fi
 
 IFS=' '


### PR DESCRIPTION
A call to ```rosrun rosprolog rosprolog-test PKG-A,PKG-B``` would run tests for ```PKG-A, PKG-B```, and all their dependencies. 

To me, the testing of the dependencies seems like a bug because one could just add them as further packages to test. 

This pull request changes the behavior to only test ```PKG-A``` and ```PKG-B```, and not the dependencies.