### PR TITLE
Augment owl_has reasoning

### DIFF
--- a/knowrob_common/prolog/owl.pl
+++ b/knowrob_common/prolog/owl.pl
@@ -42,12 +42,6 @@
 	    owl_individual_from_range/2,
 
 
-
-owl_chain_property/2,
-kr_get_props/3,
-kr_circular_chain/2,
-
-
 	    owl_direct_subclass_of/2,	% ?Resource, ?Class
 	    owl_subclass_of/2,		% ?Class, ?Super
 

--- a/knowrob_common/prolog/owl.pl
+++ b/knowrob_common/prolog/owl.pl
@@ -817,25 +817,13 @@ owl_has_property_chain(S, PropChain, O) :-
 owl_has_property_chain_S2O(O, [], O).
 
 owl_has_property_chain_S2O(S, [P|RestChain], O) :-
-        owl_individual_of(P, owl:'ObjectProperty'),
         owl_has(S, P, Oi),
-        owl_has_property_chain_S2O(Oi, RestChain, O).
-
-owl_has_property_chain_S2O(S, [P|RestChain], O) :-
-        owl_has(P, owl:inverseOf, PI),
-        owl_has(Oi, PI, S),
         owl_has_property_chain_S2O(Oi, RestChain, O).
 
 owl_has_property_chain_O2S(S, [], S).
 
 owl_has_property_chain_O2S(O, [P|RestChain], S) :-
-        owl_individual_of(P, owl:'ObjectProperty'),
         owl_has(Si, P, O),
-        owl_has_property_chain_O2S(Si, RestChain, S).
-
-owl_has_property_chain_O2S(O, [P|RestChain], S) :-
-        owl_has(P, owl:inverseOf, PI),
-        owl_has(O, PI, Si),
         owl_has_property_chain_O2S(Si, RestChain, S).
 
 owl_use_rule(S, P, O):-


### PR DESCRIPTION
with PropertyChain for object properties.

Example PropertyChain:

object property hP is defined in an ontology as a property chain of object properties uC o inverse hA (o is part of syntax here). We then assert rdf triples (s, uC, c), (p, hA, c) and nothing else. The property chain means that implicitly we also have (s, hP, p).

Old version: owl_has(s, hP, p) fails.

New version: owl_has(s, hP, p) succeeds.

The modifications to the owl_has predicate were tested. They also include some sanity checks (they will not follow circular property chains). In case of finding rdf triples (S, R, O) through a property chain, R and at least one of S or O must be bound.
