### PR TITLE
fixed compile error

### DIFF
--- a/json_prolog/json_prolog/src/main/java/org/knowrob/json_prolog/query/JSONQuery.java
+++ b/json_prolog/json_prolog/src/main/java/org/knowrob/json_prolog/query/JSONQuery.java
@@ -73,13 +73,14 @@ public class JSONQuery {
         result.put(e.getKey(), e.getValue().doubleValue());
       else if (e.getValue().isInteger())
         result.put(e.getKey(), e.getValue().intValue());
-      else if ((e.getValue().isCompound() && !e.getValue().isAtom()) || e.getValue().isListNil()) {
+      else if (e.getValue().isCompound() && !e.getValue().isAtom()) {
         if (isList(e.getValue()))
           result.put(e.getKey(), encodeList(e.getValue()));
         else
           result.put(e.getKey(), encodeCompoundTerm(e.getValue()));
-      }
-      else {
+      } else if (e.getValue().name().equals("[]")){
+        result.put(e.getKey(), e.getValue().name());
+      } else {
         // Warp atom in single quotes in order to avoid that the value is
         // converted to some JSON data structure (e.g., JSONObject, JSONArray, ...)
         result.put(e.getKey(), "'"+e.getValue().name()+"'");


### PR DESCRIPTION
This should fix the compile error. However, it does not completely fix the bug I was trying to fix with my initial pull request.
With this version I get the following results:
query: A=[]
result: []
query: A='[]'
result: [] <-- this should be an atom
It is not so easy to fix this properly because I couldn't find good jpl3 documentation, maybe we should just switch to jpl7 for the master branch as well?