### PR TITLE
Add geometry_msgs to package.xml

### DIFF
--- a/knowrob_objects/package.xml
+++ b/knowrob_objects/package.xml
@@ -18,6 +18,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosprolog</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
   <run_depend>knowrob_common</run_depend>


### PR DESCRIPTION
Compiling kinetic from scratch yields this error:

```
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:18: error: package geometry_msgs does not exist
  geometry_msgs.Vector3 getSize();
               ^
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:19: error: package geometry_msgs does not exist
  void setSize(geometry_msgs.Vector3 value);
                            ^
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:20: error: package geometry_msgs does not exist
  geometry_msgs.PoseStamped getPose();
               ^
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:21: error: package geometry_msgs does not exist
  void setPose(geometry_msgs.PoseStamped value);
                            ^
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:22: error: package geometry_msgs does not exist
  java.util.List<geometry_msgs.TransformStamped> getStaticTransforms();
                              ^
/home/ros/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:23: error: package geometry_msgs does not exist
  void setStaticTransforms(java.util.List<geometry_msgs.TransformStamped> value);
                                                       ^
6 errors
1 warning
```

Adding geometry_msgs as a build dependency fixes this error.