### PR TITLE
Added geometry_msg as build dependency

### DIFF
--- a/knowrob_objects/package.xml
+++ b/knowrob_objects/package.xml
@@ -18,6 +18,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rosprolog</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   
   <run_depend>message_runtime</run_depend>
   <run_depend>knowrob_common</run_depend>


### PR DESCRIPTION
I was [building knowrob-base](http://knowrob.org/installation/catkin) on Ubuntu 16.04 and got the following errors:

/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:18: error: package geometry_msgs does not exist
  geometry_msgs.Vector3 getSize();
               ^
/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:19: error: package geometry_msgs does not exist
  void setSize(geometry_msgs.Vector3 value);
                            ^
/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:20: error: package geometry_msgs does not exist
  geometry_msgs.PoseStamped getPose();
               ^
/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:21: error: package geometry_msgs does not exist
  void setPose(geometry_msgs.PoseStamped value);
                            ^
/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:22: error: package geometry_msgs does not exist
  geometry_msgs.PoseStamped getStaticTransforms();
               ^
/home/jose/catkin_ws/build/knowrob/knowrob_objects/java/knowrob_objects/src/main/java/knowrob_objects/ObjectState.java:23: error: package geometry_msgs does not exist
  void setStaticTransforms(geometry_msgs.PoseStamped value);
                                        ^
6 errors

I had to do this change locally to fix the error.
