### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ We have prepared different *.rosinstall* setup files that you can add to your RO
 ```Bash
 rosdep update
 cd ~/catkin_ws/src
+wstool init
 wstool merge https://raw.github.com/knowrob/knowrob/master/rosinstall/knowrob-base.rosinstall
 wstool update
 rosdep install --ignore-src --from-paths .


### PR DESCRIPTION
Add `wstool init` to installation instructions in case a wstool workspace hasn't been created yet.

This line can save a lot of time for people who aren't as familiar with wstool. If their workspace already has a wstool workspace then this extra line does no harm.