### PR TITLE
Fix remote mongo login without authentication

### DIFF
--- a/src/db/mongo/MongoInterface.cpp
+++ b/src/db/mongo/MongoInterface.cpp
@@ -8,7 +8,6 @@
 
 #include <mongoc.h>
 #include <sstream>
-#include <iostream>
 
 #include <rosprolog/rosprolog_kb/rosprolog_kb.h>
 
@@ -94,14 +93,12 @@ MongoInterface::MongoInterface()
 	bson_error_t err;
 	std::string mongo_uri;
 	if(!rosprolog_kb::node().getParam(std::string("mongodb_uri"),mongo_uri)) {
-		std::cout << "p1" << std::endl;
 		char *mongo_host = std::getenv("KNOWROB_MONGO_HOST");
 		char *mongo_user_name = std::getenv("KNOWROB_MONGO_USER");
 		char *mongo_user_pw = std::getenv("KNOWROB_MONGO_PASS");
 		char *mongo_database = std::getenv("KNOWROB_MONGO_DB");
 		char *mongo_port = std::getenv("KNOWROB_MONGO_PORT");
 		if(mongo_host != NULL && mongo_user_name != NULL) {
-			std::cout << "p1.1" << std::endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_user_name << ":" << mongo_user_pw
 				<< "@" << mongo_host << ":" << mongo_port << "/" << mongo_database
@@ -111,7 +108,6 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else if(mongo_host != NULL) {
-			std::cout << "p1.2" << std::endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_host << ":" << mongo_port << "/" << mongo_database
 				// FIXME: this should be a parameter
@@ -120,11 +116,9 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else {
-			std::cout << "p1.3" << std::endl;
 			mongo_uri = std::string("mongodb://localhost:27017/?appname=knowrob");
 		}
 	}
-	std::cout << mongo_uri << std::endl;
 	uri_ = mongoc_uri_new_with_error(mongo_uri.c_str(),&err);
 	if(!uri_) {
 		throw MongoException("invalid_uri",err);

--- a/src/db/mongo/MongoInterface.cpp
+++ b/src/db/mongo/MongoInterface.cpp
@@ -8,6 +8,7 @@
 
 #include <mongoc.h>
 #include <sstream>
+#include <iostream>
 
 #include <rosprolog/rosprolog_kb/rosprolog_kb.h>
 
@@ -93,12 +94,14 @@ MongoInterface::MongoInterface()
 	bson_error_t err;
 	std::string mongo_uri;
 	if(!rosprolog_kb::node().getParam(std::string("mongodb_uri"),mongo_uri)) {
+		cout << "p1" << endl;
 		char *mongo_host = std::getenv("KNOWROB_MONGO_HOST");
 		char *mongo_user_name = std::getenv("KNOWROB_MONGO_USER");
 		char *mongo_user_pw = std::getenv("KNOWROB_MONGO_PASS");
 		char *mongo_database = std::getenv("KNOWROB_MONGO_DB");
 		char *mongo_port = std::getenv("KNOWROB_MONGO_PORT");
 		if(mongo_host != NULL && mongo_user_name != NULL) {
+			cout << "p1.1" << endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_user_name << ":" << mongo_user_pw
 				<< "@" << mongo_host << ":" << mongo_port << "/" << mongo_database
@@ -108,6 +111,7 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else if(mongo_host != NULL) {
+			cout << "p1.2" << endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_host << ":" << mongo_port << "/" << mongo_database
 				// FIXME: this should be a parameter
@@ -116,9 +120,11 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else {
+			cout << "p1.3" << endl;
 			mongo_uri = std::string("mongodb://localhost:27017/?appname=knowrob");
 		}
 	}
+	cout << mongo_uri << endl;
 	uri_ = mongoc_uri_new_with_error(mongo_uri.c_str(),&err);
 	if(!uri_) {
 		throw MongoException("invalid_uri",err);

--- a/src/db/mongo/MongoInterface.cpp
+++ b/src/db/mongo/MongoInterface.cpp
@@ -107,7 +107,7 @@ MongoInterface::MongoInterface()
 				;
 			mongo_uri = ss.str();
 		}
-		else if(!mongo_host != NULL) {
+		else if(mongo_host != NULL) {
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_host << ":" << mongo_port << "/" << mongo_database
 				// FIXME: this should be a parameter

--- a/src/db/mongo/MongoInterface.cpp
+++ b/src/db/mongo/MongoInterface.cpp
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2020, Daniel Beßler
  * All rights reserved.
- * 
+ *
  * This file is part of KnowRob, please consult
  * https://github.com/knowrob/knowrob for license details.
  */
@@ -94,14 +94,22 @@ MongoInterface::MongoInterface()
 	std::string mongo_uri;
 	if(!rosprolog_kb::node().getParam(std::string("mongodb_uri"),mongo_uri)) {
 		char *mongo_host = std::getenv("KNOWROB_MONGO_HOST");
-		if(mongo_host != NULL) {
-			char *mongo_user_name = std::getenv("KNOWROB_MONGO_USER");
-			char *mongo_user_pw = std::getenv("KNOWROB_MONGO_PASS");
-			char *mongo_database = std::getenv("KNOWROB_MONGO_DB");
-			char *mongo_port = std::getenv("KNOWROB_MONGO_PORT");
+		char *mongo_user_name = std::getenv("KNOWROB_MONGO_USER");
+		char *mongo_user_pw = std::getenv("KNOWROB_MONGO_PASS");
+		char *mongo_database = std::getenv("KNOWROB_MONGO_DB");
+		char *mongo_port = std::getenv("KNOWROB_MONGO_PORT");
+		if(mongo_host != NULL && mongo_user_name != NULL) {
 			std::stringstream ss;
-			ss << "mongodb://" << mongo_user_name << ":" << mongo_user_pw 
+			ss << "mongodb://" << mongo_user_name << ":" << mongo_user_pw
 				<< "@" << mongo_host << ":" << mongo_port << "/" << mongo_database
+				// FIXME: this should be a parameter
+				//<< "?authSource=admin"
+				;
+			mongo_uri = ss.str();
+		}
+		else if(!mongo_host != NULL) {
+			std::stringstream ss;
+			ss << "mongodb://" << mongo_host << ":" << mongo_port << "/" << mongo_database
 				// FIXME: this should be a parameter
 				//<< "?authSource=admin"
 				;

--- a/src/db/mongo/MongoInterface.cpp
+++ b/src/db/mongo/MongoInterface.cpp
@@ -94,14 +94,14 @@ MongoInterface::MongoInterface()
 	bson_error_t err;
 	std::string mongo_uri;
 	if(!rosprolog_kb::node().getParam(std::string("mongodb_uri"),mongo_uri)) {
-		cout << "p1" << endl;
+		std::cout << "p1" << std::endl;
 		char *mongo_host = std::getenv("KNOWROB_MONGO_HOST");
 		char *mongo_user_name = std::getenv("KNOWROB_MONGO_USER");
 		char *mongo_user_pw = std::getenv("KNOWROB_MONGO_PASS");
 		char *mongo_database = std::getenv("KNOWROB_MONGO_DB");
 		char *mongo_port = std::getenv("KNOWROB_MONGO_PORT");
 		if(mongo_host != NULL && mongo_user_name != NULL) {
-			cout << "p1.1" << endl;
+			std::cout << "p1.1" << std::endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_user_name << ":" << mongo_user_pw
 				<< "@" << mongo_host << ":" << mongo_port << "/" << mongo_database
@@ -111,7 +111,7 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else if(mongo_host != NULL) {
-			cout << "p1.2" << endl;
+			std::cout << "p1.2" << std::endl;
 			std::stringstream ss;
 			ss << "mongodb://" << mongo_host << ":" << mongo_port << "/" << mongo_database
 				// FIXME: this should be a parameter
@@ -120,11 +120,11 @@ MongoInterface::MongoInterface()
 			mongo_uri = ss.str();
 		}
 		else {
-			cout << "p1.3" << endl;
+			std::cout << "p1.3" << std::endl;
 			mongo_uri = std::string("mongodb://localhost:27017/?appname=knowrob");
 		}
 	}
-	cout << mongo_uri << endl;
+	std::cout << mongo_uri << std::endl;
 	uri_ = mongoc_uri_new_with_error(mongo_uri.c_str(),&err);
 	if(!uri_) {
 		throw MongoException("invalid_uri",err);

--- a/src/db/mongo/client.pl
+++ b/src/db/mongo/client.pl
@@ -619,7 +619,6 @@ mng_strip_variable(X,X) :- !.
 % Get the URI connection string
 %
 mng_uri(URI) :-
-  write("found user and pass"),
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_USER', User),
   getenv('KNOWROB_MONGO_PASS', Pass),
@@ -629,7 +628,6 @@ mng_uri(URI) :-
   !.
 
 mng_uri(URI) :-
-  write("trying remote access"),
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_PORT', Port),
   atomic_list_concat([ 'mongodb://', Host, ':', Port ], URI),

--- a/src/db/mongo/client.pl
+++ b/src/db/mongo/client.pl
@@ -86,7 +86,7 @@ To this end, Prolog datastructures are translated from and into BSON format.
 %
 mng_get_db(DB, Collection, DBType) :-
 	mng_db_name(DB),
-	(	(setting(mng_client:collection_prefix, Id), Id \= '') 
+	(	(setting(mng_client:collection_prefix, Id), Id \= '')
 	->	atomic_list_concat([Id,'_',DBType], Collection)
 	;	Collection = DBType
 	).
@@ -186,8 +186,8 @@ mng_find(DB, Collection, Filter, Result) :-
 		% cleanup: destroy cursor again
 		mng_cursor_destroy(Cursor)
 	).
-  
-  
+
+
 % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
 % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
 % % % % % regex
@@ -395,7 +395,7 @@ mng_restore(_DB,Dir) :-
 % @param Document the query document
 %
 mng_query_value(Value0, [Operator, Value1]) :-
-	% remove _->_ expression for vars 
+	% remove _->_ expression for vars
 	mng_strip_variable(Value0, X0),
 	% rest term must be grounded
 	ground(X0),
@@ -625,6 +625,12 @@ mng_uri(URI) :-
   getenv('KNOWROB_MONGO_PORT', Port),
   atomic_list_concat([ 'mongodb://', User, ':', Pass,
     '@', Host, ':', Port ], URI),
+  !.
+
+mng_uri(URI) :-
+  getenv('KNOWROB_MONGO_HOST', Host),
+  getenv('KNOWROB_MONGO_PORT', Port),
+  atomic_list_concat([ 'mongodb://', Host, ':', Port ], URI),
   !.
 
 mng_uri('mongodb://localhost:27017').

--- a/src/db/mongo/client.pl
+++ b/src/db/mongo/client.pl
@@ -619,7 +619,7 @@ mng_strip_variable(X,X) :- !.
 % Get the URI connection string
 %
 mng_uri(URI) :-
-  write("found user and pass")
+  write("found user and pass"),
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_USER', User),
   getenv('KNOWROB_MONGO_PASS', Pass),
@@ -629,7 +629,7 @@ mng_uri(URI) :-
   !.
 
 mng_uri(URI) :-
-  write("trying remote access")
+  write("trying remote access"),
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_PORT', Port),
   atomic_list_concat([ 'mongodb://', Host, ':', Port ], URI),

--- a/src/db/mongo/client.pl
+++ b/src/db/mongo/client.pl
@@ -619,6 +619,7 @@ mng_strip_variable(X,X) :- !.
 % Get the URI connection string
 %
 mng_uri(URI) :-
+  write("found user and pass")
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_USER', User),
   getenv('KNOWROB_MONGO_PASS', Pass),
@@ -628,6 +629,7 @@ mng_uri(URI) :-
   !.
 
 mng_uri(URI) :-
+  write("trying remote access")
   getenv('KNOWROB_MONGO_HOST', Host),
   getenv('KNOWROB_MONGO_PORT', Port),
   atomic_list_concat([ 'mongodb://', Host, ':', Port ], URI),


### PR DESCRIPTION
As stated in Issue #305, KnowRob doesn't allow a connection to Mongo that is remote and without authentication, right now. 

When these two environment variables are set like this
```
KNOWROB_MONGO_HOST=localhost # or any remote. The error stays the same
KNOWROB_MONGO_PORT=27017
```
KnowRob shuts down with the following error message:
```
ERROR:    Unhandled exception: mng_error(invalid_uri('Invalid host string in URI'))
[ERROR] [1632778849.817918826]: mng_error(invalid_uri('Invalid host string in URI'))
[ERROR] [1632778849.818084663]: Failed to load initial_package knowrob.
[ERROR] [1632778849.818247573]: rosprolog service failed to initialize.
```

Since there are (possibly rare) use cases where users need such a setup, I propose this fix.
In my case, I needed this as part of a dind setup.