### PR TITLE
Support for storing and loading wrenches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(mongo_kb
 add_library(tf_knowrob SHARED
 	src/ros/tf/tf.cpp
 	src/ros/tf/memory.cpp
-	src/ros/tf/logger.cpp
+		src/ros/tf/logger.cpp
 	src/ros/tf/publisher.cpp
 	src/ros/tf/republisher.cpp)
 target_link_libraries(tf_knowrob
@@ -95,6 +95,19 @@ target_link_libraries(tf_knowrob
 	${catkin_LIBRARIES}
 	mongo_kb)
 add_dependencies(tf_knowrob
+	${${PROJECT_NAME}_EXPORTED_TARGETS}
+	${catkin_EXPORTED_TARGETS})
+
+add_library(wrench_knowrob SHARED
+	src/ros/wrench/wrench.cpp
+	src/ros/wrench/memory.cpp
+	src/ros/wrench/logger.cpp)
+target_link_libraries(wrench_knowrob
+	${SWIPL_LIBRARIES}
+	${MONGOC_LIBRARIES}
+	${catkin_LIBRARIES}
+	mongo_kb)
+add_dependencies(wrench_knowrob
 	${${PROJECT_NAME}_EXPORTED_TARGETS}
 	${catkin_EXPORTED_TARGETS})
 

--- a/include/knowrob/ros/wrench/logger.h
+++ b/include/knowrob/ros/wrench/logger.h
@@ -1,0 +1,75 @@
+#ifndef __KNOWROB_WRENCH_LOGGER__
+#define __KNOWROB_WRENCH_LOGGER__
+
+#include <string>
+
+// MONGO
+#include <mongoc.h>
+// ROS
+#include <ros/ros.h>
+#include <geometry_msgs/WrenchStamped.h>
+// SWI Prolog
+#define PL_SAFE_ARG_MACROS
+#include <SWI-cpp.h>
+
+#include <knowrob/ros/wrench/memory.h>
+
+/**
+ * A wrench listener that stores messages in MongoDB.
+ */
+class WrenchLogger
+{
+public:
+	WrenchLogger(ros::NodeHandle &node,
+			WrenchMemory &memory,
+			const std::string &topic="wrench");
+	~WrenchLogger();
+
+	void set_db_name(const std::string &db_name)
+	{ db_name_ = db_name; }
+
+	const std::string& get_db_name()
+	{ return db_name_; }
+
+	void set_time_threshold(double v)
+	{ timeThreshold_ = v; }
+
+	double get_time_threshold() const
+	{ return timeThreshold_; }
+
+	void set_force_threshold(double v)
+	{ forceThreshold_ = v; }
+
+	double get_force_threshold() const
+	{ return forceThreshold_; }
+
+	void set_torque_threshold(double v)
+	{ torqueThreshold_ = v; }
+
+	double get_torque_threshold() const
+	{ return torqueThreshold_; }
+
+	void store(const geometry_msgs::WrenchStamped &ws);
+
+protected:
+	ros::Subscriber subscriber_;
+	WrenchMemory &memory_;
+	double forceThreshold_;
+	double torqueThreshold_;
+	double timeThreshold_;
+	std::string db_name_;
+	std::string topic_;
+
+	char buf_[16];
+	size_t keylen_;
+
+	void store_document(bson_t *doc);
+
+	bool ignoreWrench(const geometry_msgs::WrenchStamped &ws);
+
+	void callback(const geometry_msgs::WrenchStamped& msg);
+
+	void appendWrench(bson_t *ws_doc, const geometry_msgs::WrenchStamped &ws);
+};
+
+#endif //__KNOWROB_WRENCH_LOGGER__

--- a/include/knowrob/ros/wrench/memory.h
+++ b/include/knowrob/ros/wrench/memory.h
@@ -1,0 +1,84 @@
+#ifndef __KNOWROB_WRENCH_MEMORY__
+#define __KNOWROB_WRENCH_MEMORY__
+
+#include <string>
+#include <set>
+#include <map>
+#include <mutex>
+
+// MONGO
+#include <mongoc.h>
+// ROS
+#include <ros/ros.h>
+#include <geometry_msgs/WrenchStamped.h>
+// SWI Prolog
+#define PL_SAFE_ARG_MACROS
+#include <SWI-cpp.h>
+
+/**
+ * A cache of most recent wrenches.
+ */
+class WrenchMemory
+{
+public:
+	WrenchMemory();
+
+	/**
+	 * True if a wrench for a given frame was added before.
+	 */
+	bool has_wrench(const std::string &frame) const;
+
+	/**
+	 * Clears cached wrenches and the list of managed frames.
+	 */
+	bool clear();
+
+	/**
+	 * Clears cached wrenches.
+	 */
+	bool clear_wrenches_only();
+
+	/**
+	 * Get the wrench associated to a frame.
+	 */
+	const geometry_msgs::WrenchStamped& get_wrench(const std::string &frame, int buffer_index=0) const;
+
+	/**
+	 * Read a Prolog wrench term into WrenchStamped.
+	 */
+	void create_wrench(geometry_msgs::WrenchStamped *ts, const std::string &frame, const PlTerm &term, double stamp);
+
+	/**
+	 * Add a wrench, overwriting any previous wrench with same frame.
+	 */
+	void set_wrench(const geometry_msgs::WrenchStamped &ts);
+
+	/**
+	 * Add a wrench, overwriting any previous wrench with same frame.
+	 */
+	void set_managed_wrench(const geometry_msgs::WrenchStamped &ts);
+
+	/**
+	 * Read Prolog wrench term for frame.
+	 */
+	bool get_wrench_term(const std::string &frame, PlTerm *term, double *stamp);
+
+	/**
+	 * Add a wrench, overwriting any previous wrench with same frame.
+	 */
+	bool set_wrench_term(const std::string &frame, const PlTerm &term, double stamp);
+
+	/**
+	 * True for frames which are managed by the KB.
+	 */
+	bool is_managed_frame(const std::string &frame) const;
+
+protected:
+	std::set<std::string> managed_frames_[2];
+	std::map<std::string, geometry_msgs::WrenchStamped> wrenches_[2];
+	std::mutex wrenches_lock_;
+	std::mutex names_lock_;
+	int buffer_index_;
+};
+
+#endif //__KNOWROB_WRENCH_MEMORY__

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -54,9 +54,26 @@ annotation_property('http://www.w3.org/2002/07/owl#versionInfo').
 % @param Directory filesystem path
 %
 remember(Directory) :-
-	mng_import(Directory).
+	mng_import_all(Directory).
 
-%%
+%% Import all collections from a directory into MongoDB.
+% Also imports collections which do not exist yet in the database.
+%
+mng_import_all(Dir) :-
+	listdir(Dir, Collections),
+	mng_import_all(Dir, Collections).
+mng_import_all(_, []).
+mng_import_all(Dir, [Coll1|Collections]) :-
+	path_concat(Dir, Coll1, Dir0),
+	% Get the name of the database
+	listdir(Dir0, Entries),
+	member(DB, Entries),
+	mng_restore(DB, Dir0),
+	mng_import_all(Dir, Collections),!.
+
+%% Import the contents of a directory into MongoDB.
+% Only collections which already exist in the database are restored.
+%
 mng_import(Dir) :-
 	forall(
 		(	collection_name(Name),

--- a/src/ros/__init__.pl
+++ b/src/ros/__init__.pl
@@ -3,3 +3,4 @@
 :- use_directory('urdf').
 :- use_directory('tf').
 :- use_directory('marker').
+:- use_directory('wrench').

--- a/src/ros/wrench/README.md
+++ b/src/ros/wrench/README.md
@@ -1,0 +1,8 @@
+Force/torque integration
+=======
+
+KnowRob supports storing and loading subsymbolic data about wrenches (forces & torques) acting on objects. This works exactly like the mechanism for loading and storing /tf.
+
+Wrenches are always associated with the object they act on. The wrench is defined relative to that object's local coordinate system. See `wrench.plt` for examples.
+
+Unlike tf data, wrench data cannot be transformed into other coordinate systems by KnowRob (yet). Support for wrench transformations as well as gravity/lever compensation is planned for the future.

--- a/src/ros/wrench/__init__.pl
+++ b/src/ros/wrench/__init__.pl
@@ -1,0 +1,3 @@
+
+:- use_module('wrench_mongo').
+:- use_module('wrench').

--- a/src/ros/wrench/logger.cpp
+++ b/src/ros/wrench/logger.cpp
@@ -1,0 +1,121 @@
+#include <knowrob/ros/wrench/logger.h>
+#include <knowrob/db/mongo/MongoInterface.h>
+
+WrenchLogger::WrenchLogger(ros::NodeHandle &node, WrenchMemory &memory, const std::string &topic)
+	: memory_(memory), timeThreshold_(-1.0), forceThreshold_(0.001), torqueThreshold_(0.001),
+	  db_name_("roslog"), topic_(topic), subscriber_(node.subscribe(topic, 1000, &WrenchLogger::callback, this))
+{
+}
+
+WrenchLogger::~WrenchLogger()
+{
+}
+
+void WrenchLogger::store_document(bson_t *doc)
+{
+	bson_error_t err;
+	MongoCollection *collection = MongoInterface::get_collection(db_name_.c_str(),topic_.c_str());
+	if(!mongoc_collection_insert(
+			(*collection)(),MONGOC_INSERT_NONE,doc,NULL,&err))
+	{
+		ROS_WARN("[WrenchLogger] insert failed: %s.", err.message);
+	}
+	delete collection;
+}
+
+void WrenchLogger::store(const geometry_msgs::WrenchStamped &ws)
+{
+	bson_t *doc = bson_new();
+	appendWrench(doc, ws);
+	BSON_APPEND_DATE_TIME(doc, "__recorded", time(NULL) * 1000);
+	BSON_APPEND_UTF8(doc, "__topic", topic_.c_str());
+	store_document(doc);
+	bson_destroy(doc);
+}
+
+void WrenchLogger::callback(const geometry_msgs::WrenchStamped& ws)
+{
+	if(!ignoreWrench(ws)) {
+		store(ws);
+		if(!memory_.is_managed_frame(ws.header.frame_id)) {
+			memory_.set_wrench(ws);
+		}
+	}
+}
+
+bool WrenchLogger::ignoreWrench(const geometry_msgs::WrenchStamped &ws0)
+{
+	const std::string &frame_id  = ws0.header.frame_id;
+	if(!memory_.has_wrench(frame_id)) {
+		// it's a new frame
+		return false;
+	}
+	if(memory_.is_managed_frame(frame_id)) {
+		// managed frames are asserted into DB back-end directly
+		return true;
+	}
+	const geometry_msgs::WrenchStamped &ws1 = memory_.get_wrench(frame_id);
+	// test whether temporal distance exceeds threshold
+	if(timeThreshold_>0.0) {
+		double timeDistance = (
+				(ws0.header.stamp.sec * 1000.0 + ws0.header.stamp.nsec / 1000000.0) -
+				(ws1.header.stamp.sec * 1000.0 + ws1.header.stamp.nsec / 1000000.0)) / 1000.0;
+		if(timeDistance<0 || timeDistance > timeThreshold_) {
+			return false;
+		}
+	}
+	// test whether force distance exceeds threshold
+	const geometry_msgs::Vector3 &force0 = ws0.wrench.force;
+	const geometry_msgs::Vector3 &force1 = ws1.wrench.force;
+	double forceDistance = sqrt(
+			((force0.x - force1.x) * (force0.x - force1.x)) +
+			((force0.y - force1.y) * (force0.y - force1.y)) +
+			((force0.z - force1.z) * (force0.z - force1.z)));
+	if(forceDistance > forceThreshold_) {
+		return false;
+	}
+	// test whether torque distance exceeds threshold
+	const geometry_msgs::Vector3 &torque0 = ws0.wrench.torque;
+	const geometry_msgs::Vector3 &torque1 = ws1.wrench.torque;
+	double torqueDistance = sqrt(
+			((torque0.x - torque1.x) * (torque0.x - torque1.x)) +
+			((torque0.y - torque1.y) * (torque0.y - torque1.y)) +
+			((torque0.z - torque1.z) * (torque0.z - torque1.z)));
+	if(torqueDistance > torqueThreshold_) {
+		return false;
+	}
+	return true;
+}
+
+void WrenchLogger::appendWrench(bson_t *ws_doc, const geometry_msgs::WrenchStamped &ws)
+{
+	bson_t child, child2;
+	// append header
+	BSON_APPEND_DOCUMENT_BEGIN(ws_doc, "header", &child); {
+		unsigned long long time = (unsigned long long)(
+				ws.header.stamp.sec * 1000.0 + ws.header.stamp.nsec / 1000000.0);
+		//
+		BSON_APPEND_INT32(&child, "seq", ws.header.seq);
+		BSON_APPEND_DATE_TIME(&child, "stamp", time);
+		BSON_APPEND_UTF8(&child, "frame_id", ws.header.frame_id.c_str());
+		bson_append_document_end(ws_doc, &child);
+	}
+	// append wrench
+	BSON_APPEND_DOCUMENT_BEGIN(ws_doc, "wrench", &child); {
+		// append force
+		BSON_APPEND_DOCUMENT_BEGIN(&child, "force", &child2); {
+			BSON_APPEND_DOUBLE(&child2, "x", ws.wrench.force.x);
+			BSON_APPEND_DOUBLE(&child2, "y", ws.wrench.force.y);
+			BSON_APPEND_DOUBLE(&child2, "z", ws.wrench.force.z);
+			bson_append_document_end(&child, &child2);
+		}
+		// append torque
+		BSON_APPEND_DOCUMENT_BEGIN(&child, "torque", &child2); {
+			BSON_APPEND_DOUBLE(&child2, "x", ws.wrench.torque.x);
+			BSON_APPEND_DOUBLE(&child2, "y", ws.wrench.torque.y);
+			BSON_APPEND_DOUBLE(&child2, "z", ws.wrench.torque.z);
+			bson_append_document_end(&child, &child2);
+		}
+		bson_append_document_end(ws_doc, &child);
+	}
+}

--- a/src/ros/wrench/memory.cpp
+++ b/src/ros/wrench/memory.cpp
@@ -1,0 +1,146 @@
+#include <knowrob/ros/wrench/memory.h>
+
+static inline double get_stamp(const geometry_msgs::WrenchStamped &msg)
+{
+	unsigned long long time = (unsigned long long)(
+			msg.header.stamp.sec * 1000.0 + msg.header.stamp.nsec / 1000000.0);
+	return (double)(time/1000.0);
+}
+
+static geometry_msgs::WrenchStamped dummy;
+
+WrenchMemory::WrenchMemory() :
+		buffer_index_(0)
+{
+}
+
+bool WrenchMemory::has_wrench(const std::string &frame) const
+{
+	return wrenches_[buffer_index_].find(frame) != wrenches_[buffer_index_].end();
+}
+
+bool WrenchMemory::is_managed_frame(const std::string &frame) const
+{
+	return managed_frames_[buffer_index_].find(frame) != managed_frames_[buffer_index_].end();
+}
+
+bool WrenchMemory::clear()
+{
+	std::lock_guard<std::mutex> guard1(wrenches_lock_);
+	std::lock_guard<std::mutex> guard2(names_lock_);
+	wrenches_[buffer_index_].clear();
+	managed_frames_[buffer_index_].clear();
+	return true;
+}
+
+bool WrenchMemory::clear_wrenches_only()
+{
+	std::lock_guard<std::mutex> guard1(wrenches_lock_);
+	wrenches_[buffer_index_].clear();
+	return true;
+}
+
+const geometry_msgs::WrenchStamped& WrenchMemory::get_wrench(
+		const std::string &frame, int buffer_index) const
+{
+	const std::map<std::string, geometry_msgs::WrenchStamped>::const_iterator
+		&needle = wrenches_[buffer_index].find(frame);
+	if(needle != wrenches_[buffer_index].end()) {
+		return needle->second;
+	}
+	else {
+		return dummy;
+	}
+}
+
+void WrenchMemory::set_wrench(const geometry_msgs::WrenchStamped &ws)
+{
+	std::lock_guard<std::mutex> guard(wrenches_lock_);
+	wrenches_[buffer_index_][ws.header.frame_id] = ws;
+}
+
+void WrenchMemory::set_managed_wrench(const geometry_msgs::WrenchStamped &ws)
+{
+	std::lock_guard<std::mutex> guard1(wrenches_lock_);
+	std::lock_guard<std::mutex> guard2(names_lock_);
+	managed_frames_[buffer_index_].insert(ws.header.frame_id);
+	wrenches_[buffer_index_][ws.header.frame_id] = ws;
+}
+
+bool WrenchMemory::get_wrench_term(const std::string &frame, PlTerm *term, double *stamp)
+{
+	if(!has_wrench(frame)) return false;
+	const geometry_msgs::WrenchStamped &ws = get_wrench(frame);
+
+	PlTail wrench_list(*term); {
+		wrench_list.append(ws.header.frame_id.c_str());
+		//
+		PlTerm force_term;
+		PlTail force_list(force_term); {
+			force_list.append(ws.wrench.force.x);
+			force_list.append(ws.wrench.force.y);
+			force_list.append(ws.wrench.force.z);
+			force_list.close();
+		}
+		wrench_list.append(force_term);
+		//
+		PlTerm torque_term;
+		PlTail torque_list(torque_term); {
+			torque_list.append(ws.wrench.force.x);
+			torque_list.append(ws.wrench.force.y);
+			torque_list.append(ws.wrench.force.z);
+			torque_list.close();
+		}
+		wrench_list.append(torque_term);
+		wrench_list.close();
+	}
+	// get unix timestamp
+	*stamp = get_stamp(ws);
+
+	return true;
+}
+
+bool WrenchMemory::set_wrench_term(const std::string &frame, const PlTerm &term, double stamp)
+{
+	const geometry_msgs::WrenchStamped &ws_old = get_wrench(frame);
+	// make sure the wrench is more recent then the one stored
+	if(stamp<0.0) {
+		// force setting wrench if stamp<0.0
+		stamp = 0.0;
+	}
+	else if(get_stamp(ws_old)>stamp) {
+		return false;
+	}
+	//
+	geometry_msgs::WrenchStamped ws = ws_old;
+	create_wrench(&ws,frame,term,stamp);
+	set_managed_wrench(ws);
+	return true;
+}
+
+void WrenchMemory::create_wrench(
+		geometry_msgs::WrenchStamped *ws,
+		const std::string &frame,
+		const PlTerm &term,
+		double stamp)
+{
+	PlTail tail(term);
+	PlTerm e,j;
+	// header
+	ws->header.frame_id = frame;
+	unsigned long long time_ms = ((unsigned long long)(stamp*1000.0));
+	ws->header.stamp.sec  = time_ms / 1000;
+	ws->header.stamp.nsec = (time_ms % 1000) * 1000 * 1000;
+	// force
+	tail.next(e);
+	PlTail force_list(e);
+	force_list.next(j); ws->wrench.force.x =(double)j;
+	force_list.next(j); ws->wrench.force.y =(double)j;
+	force_list.next(j); ws->wrench.force.z =(double)j;
+	// torque
+	tail.next(e);
+	PlTail torque_list(e);
+	torque_list.next(j); ws->wrench.torque.x =(double)j;
+	torque_list.next(j); ws->wrench.torque.y =(double)j;
+	torque_list.next(j); ws->wrench.torque.z =(double)j;
+}

--- a/src/ros/wrench/wrench.cpp
+++ b/src/ros/wrench/wrench.cpp
@@ -1,0 +1,110 @@
+
+#include <knowrob/ros/wrench/memory.h>
+#include <knowrob/ros/wrench/logger.h>
+
+static ros::NodeHandle node;
+static WrenchMemory memory;
+static WrenchLogger *wrench_logger=NULL;
+
+// wrench logger parameter
+double force_threshold=0.001;
+double torque_threshold=0.001;
+double time_threshold=-1.0;
+std::string logger_db_name="roslog";
+
+// Clear the wrench memory to remove cached wrenches
+PREDICATE(wrench_mem_clear, 0) {
+	memory.clear();
+	return true;
+}
+
+// wrench_mem_set(ObjFrame,WrenchData,Since)
+PREDICATE(wrench_mem_set, 3) {
+	std::string frame((char*)PL_A1);
+	double stamp = (double)PL_A3;
+	memory.set_wrench_term(frame,PL_A2,stamp);
+	return true;
+}
+
+// wrench_mem_get(ObjFrame,WrenchData,Since)
+PREDICATE(wrench_mem_get, 3) {
+	std::string frame((char*)PL_A1);
+	double stamp;
+	PlTerm wrench_term;
+	if(memory.get_wrench_term(frame,&wrench_term,&stamp)) {
+		PL_A2 = wrench_term;
+		PL_A3 = stamp;
+		return true;
+	}
+	return false;
+}
+
+// wrench_logger_enable
+PREDICATE(wrench_logger_enable, 0) {
+	if(wrench_logger) {
+		delete wrench_logger;
+	}
+
+	wrench_logger = new WrenchLogger(node,memory);
+	wrench_logger->set_db_name(logger_db_name);
+	wrench_logger->set_time_threshold(time_threshold);
+	wrench_logger->set_force_threshold(force_threshold);
+	wrench_logger->set_torque_threshold(torque_threshold);
+	return true;
+}
+
+// wrench_logger_disable
+PREDICATE(wrench_logger_disable, 0) {
+	if(wrench_logger) {
+		delete wrench_logger;
+		wrench_logger = NULL;
+	}
+	return true;
+}
+
+// wrench_logger_set_db_name(DBName)
+PREDICATE(wrench_logger_set_db_name, 1) {
+	std::string db_name((char*)PL_A1);
+	logger_db_name = db_name;
+	return true;
+}
+
+//
+PREDICATE(wrench_logger_set_time_threshold, 1) {
+	time_threshold = (double)PL_A1;
+	return true;
+}
+PREDICATE(wrench_logger_set_force_threshold, 1) {
+	force_threshold = (double)PL_A1;
+	return true;
+}
+PREDICATE(wrench_logger_set_torque_threshold, 1) {
+	torque_threshold = (double)PL_A1;
+	return true;
+}
+
+//
+PREDICATE(wrench_logger_get_time_threshold, 1) {
+	PL_A1 = time_threshold;
+	return true;
+}
+PREDICATE(wrench_logger_get_force_threshold, 1) {
+	PL_A1 = force_threshold;
+	return true;
+}
+PREDICATE(wrench_logger_get_torque_threshold, 1) {
+	PL_A1 = torque_threshold;
+	return true;
+}
+
+// wrench_mng_store(ObjFrame,WrenchData,Since)
+PREDICATE(wrench_mng_store, 3) {
+	std::string frame((char*)PL_A1);
+	double stamp = (double)PL_A3;
+	geometry_msgs::WrenchStamped ws;
+	memory.create_wrench(&ws,frame,PL_A2,stamp);
+	if(wrench_logger) {
+		wrench_logger->store(ws);
+	}
+	return true;
+}

--- a/src/ros/wrench/wrench.pl
+++ b/src/ros/wrench/wrench.pl
@@ -1,0 +1,156 @@
+:- module(wrench,
+	[ wrench_set/3,
+	  wrench_get/4,
+	  wrench_mem_set/3,			% defined in wrench.cpp
+	  wrench_mem_get/3, 		% defined in wrench.cpp
+  	  wrench_mem_clear/0,		% defined in wrench.cpp
+	  wrench_logger_enable/0,	% defined in wrench.cpp
+	  wrench_logger_disable/0% defined in wrench.cpp
+	]).
+
+:- use_foreign_library('libwrench_knowrob.so').
+
+:- use_module(library(settings)).
+:- use_module(library('semweb/rdf_db'),
+	[ rdf_split_url/3 ]).
+:- use_module(library('utility/algebra'),
+	[ transform_between/3, transform_multiply/3 ]).
+:- use_module(library('lang/scope'),
+	[ scope_intersect/3,
+	  subscope_of/2,
+	  time_scope/3,
+	  time_scope_data/2,
+	  current_scope/1
+	]).
+:- use_module(library('lang/computable'),
+	[ add_computable_predicate/2 ]).
+:- use_module('wrench_mongo',
+	[ wrench_mng_lookup/6 ]).
+
+%%
+:-	mng_db_name(DB), tf_logger_set_db_name(DB).
+
+%% wrench_set(+Obj, +Data, +Scope) is det.
+%
+% Update the wrench acting on an object.
+% The wrench is updated in local memory, but also
+% written into mongo database.
+%
+wrench_set(Obj,WrenchData,FS) :-
+	rdf_split_url(_,ObjFrame,Obj),
+	time_scope_data(FS,[Since,_Until]),
+	wrench_mem_set(ObjFrame,WrenchData,Since),
+	wrench_mng_store(ObjFrame,WrenchData,Since).
+
+%%
+wrench_get(Obj,[Force,Torque]) :-
+	current_scope(QS),
+	wrench_get(Obj,[Force,Torque],QS,_FS).
+
+%% wrench_get(+Obj, ?WrenchQuery, +QueryScope, +FactScope) is semidet.
+%
+% Retrieve the wrench acting on an object.
+%
+wrench_get(Obj,WrenchQuery,QS,FS) :-
+	rdf_split_url(_,ObjFrame,Obj),
+	% lookup direct position data without doing transformations
+	has_wrench_direct(ObjFrame,WrenchData,QS,FS0),
+	% then try to unify the query
+	(  WrenchQuery=WrenchData
+	-> FS=FS0
+	% else try to compute the position in the requested frame
+	;  has_wrench_indirect(ObjFrame,WrenchQuery,WrenchData,QS,FS1)
+	-> scope_intersect(FS0,FS1,FS)
+	;  fail
+	).
+
+%% has_wrench_direct(+ObjFrame, ?WrenchData, +QS, ?FS)
+%
+% Retrieve the wrench acting on an object from the memory without transforming it.
+%
+has_wrench_direct(ObjFrame,WrenchData,QS,FS) :-
+	% get local wrench data and scope
+	wrench_mem_get(ObjFrame,WrenchData,Since),
+	get_time(Now),
+	time_scope(=(Since),=(Now),FS),
+	% make sure there is an overlap with the query scope
+	time_scope_data(QS,[QSince,QUntil]),
+	mng_strip_operator(QSince, _, QSince0),
+	mng_strip_operator(QUntil, _, QUntil0),
+	time_scope(QSince0,=(QUntil0),=(QS0)),
+	scope_intersect(FS,QS0,_),
+	% skip other results in case the fact scope is a superscope of the query scope
+	(  subscope_of(QS,FS)
+	-> !
+	;  true
+	).
+
+%% has_wrench_direct(+ObjFrame, ?WrenchData, +QS, ?FS)
+%
+% Retrieve the wrench acting on an object from the mongoDB database without transforming it.
+%
+has_wrench_direct(ObjFrame,WrenchData,QS,FS) :-
+	time_scope_data(QS,[QSince,QUntil]),
+	mng_strip_operator(QSince, _, QSince0),
+	mng_strip_operator(QUntil, _, QUntil0),
+	wrench_mng_lookup(ObjFrame,QSince0,QUntil0,WrenchData,FSince,FUntil),
+	time_scope(=(FSince),=(FUntil),FS).
+
+%%%%% Wrench transformations (not supported yet)
+%%%%% This is where lever/gravity compensation would be done
+
+% has_wrench_indirect(ObjFrame,WrenchQuery,DirectWrench,QS,FS) :-
+% 	% get wrench in world frame
+% 	world_wrench1(ObjFrame,_,DirectWrench,WorldWrench,QS,FS0),
+% 	has_wrench_indirect1(ObjFrame,WrenchQuery,WorldWrench,FS0,QS,FS).
+
+% has_wrench_indirect1(_ObjFrame,
+% 		[WorldFrame,T_query,Q_query],
+% 		[WorldFrame,T0,Q0],
+% 		FS, _QS, FS) :-
+% 	!,
+% 	% pose was requested in world frame
+% 	T_query = T0,
+% 	Q_query = Q0.
+
+% has_wrench_indirect1(ObjFrame,
+% 		[RefFrame_query,T_query,Q_query],
+% 		[WorldFrame,T0,Q0],
+% 		FS0, QS, FS) :-
+% 	% get requested frame in world frame
+% 	world_pose(RefFrame_query,WorldFrame,
+% 		[WorldFrame,T1,Q1],
+% 		QS, FS1),
+% 	%
+% 	scope_intersect(FS0,FS1,FS),
+% 	% compute transform from requested frame
+% 	% to object frame
+% 	transform_between(
+% 		[WorldFrame,     ObjFrame,       T0,Q0],
+% 		[WorldFrame,     RefFrame_query, T1,Q1],
+% 		[RefFrame_query, ObjFrame,       T_query,Q_query]
+% 	).
+
+has_wrench_indirect(ObjFrame, WrenchQuery, DirectWrench, QS, FS) :- fail.
+
+% world_pose(ObjFrame,WorldFrame,MapPose,QS,FS) :-
+% 	has_wrench_direct(ObjFrame,ObjPose,QS,FS0),
+% 	world_pose1(ObjFrame,WorldFrame,ObjPose,MapPose,QS,FS1),
+% 	scope_intersect(FS0,FS1,FS).
+
+% world_pose1(ObjFrame, WorldFrame,
+% 		[ParentFrame,T0,Q0],
+% 		[WorldFrame,T,Q],
+% 		QS, FS) :-
+% 	world_pose(ParentFrame, WorldFrame, [WorldFrame,T1,Q1], QS, FS),
+% 	!,
+% 	transform_multiply(
+% 		[WorldFrame,ParentFrame,T1,Q1],
+% 		[ParentFrame,ObjFrame,T0,Q0],
+% 		[WorldFrame,ObjFrame,T,Q]
+% 	).
+
+% world_pose1(_, WorldFrame,
+% 	[WorldFrame|Rest],
+% 	[WorldFrame|Rest], _, _).
+

--- a/src/ros/wrench/wrench.plt
+++ b/src/ros/wrench/wrench.plt
@@ -1,0 +1,107 @@
+:- use_module(library('rostest')).
+:- use_module(library('lang/query')).
+:- use_module(library('lang/scope')).
+:- use_module(library('db/mongo/client')).
+:- use_module(library('semweb/rdf_db')).
+
+:- use_module('wrench').
+:- use_module('wrench_mongo').
+
+:- begin_rdf_tests(
+		'wrench',
+		'package://knowrob/owl/test/swrl.owl',
+		[ namespace('http://knowrob.org/kb/swrl_test#'),
+		  setup(wrench_setup),
+		  cleanup(wrench_cleanup)
+		]).
+
+:- rdf_meta(test_set_wrench(r,+,+)).
+:- rdf_meta(test_get_wrench(r,+,+)).
+:- rdf_meta(test_trajectory(r,+,+,+)).
+
+wrench_setup :-
+    wrench_mng_drop,
+	wrench_logger_enable.
+
+wrench_cleanup :-
+	wrench_logger_disable,
+	wrench_mng_drop.
+
+% some test facts
+test_wrench_fred0([[1.0,0.4,2.32],[0.0,0.0,0.0]], 1593178679.123).
+test_wrench_fred1([[2.0,0.4,2.32],[0.0,0.0,0.0]], 1593178680.123).
+test_wrench_fred2([[3.0,0.4,2.32],[0.0,0.0,0.0]], 1593178681.123).
+test_wrench_alex1([[0.0,1.0,0.0],[0.0,0.0,0.0]], 1593178680.123).
+test_wrench_alex2([[0.0,0.0,1.0],[0.0,0.0,0.0]], 1593178681.123).
+test_wrench_alex3([[0.0,1.0,0.0],[0.0,0.0,0.0]], 1593178682.123).
+
+test_set_wrench(Object,Wrench,Stamp) :-
+	time_scope(=(Stamp), =<('Infinity'), FScope),
+	assert_true(wrench:wrench_set(Object,Wrench,FScope)).
+
+test_get_wrench(Object,Stamp,Expected) :-
+	time_scope(=<(Stamp), >=(Stamp), QScope),
+	assert_true(wrench:wrench_get(Object,_,QScope,_)),
+	( wrench:wrench_get(Object,Actual,QScope,_)
+	-> assert_unifies(Actual,Expected)
+	;  true
+	).
+
+test_trajectory(Obj,Begin,End,Expected) :-
+	assert_true(wrench_mongo:wrench_mng_trajectory(Obj,Begin,End,_)),
+	( wrench_mongo:wrench_mng_trajectory(Obj,Begin,End,Actual)
+	-> assert_unifies(Actual,Expected)
+	;  true
+	).
+
+test_lookup(Frame,Stamp,Expected) :-
+	assert_true(wrench:wrench_mng_lookup(Frame,Stamp,Stamp,_,_,_)),
+	( wrench:wrench_mng_lookup(Frame,Stamp,Stamp,Actual,_,_)
+	-> assert_unifies(Actual,Expected)
+	;  true
+	).
+
+test_lookup_fails(Frame,Stamp) :-
+	assert_false(wrench:wrench_mng_lookup(Frame,Stamp,Stamp,_,_,_)).
+
+test('wrench_set_get') :-
+	test_wrench_fred0(Wrench0,Stamp0),
+	Past   is Stamp0 - 1.0,
+	Future is Stamp0 + 1.0,
+	%%
+	test_set_wrench(test:'Fred',Wrench0,Stamp0),
+	test_get_wrench(test:'Fred',Stamp0,Wrench0),
+	test_get_wrench(test:'Fred',Future,Wrench0).
+
+test('wrench_mongo_lookup') :-
+	test_wrench_fred0(Wrench0,Stamp0),
+	Past is Stamp0 - 1.0,
+	test_lookup('Fred',Stamp0,Wrench0),
+	test_lookup_fails('Fred',Past).
+
+test('wrench_wrench_memory') :-
+	test_wrench_fred0(Wrench0,Stamp0),
+	test_wrench_fred1(Wrench1,Stamp1),
+	test_wrench_fred2(Wrench2,Stamp2),
+	Stamp01 is 0.5*(Stamp0 + Stamp1),
+	Future is Stamp2 + 1.0,
+	%%
+	test_set_wrench(test:'Fred',Wrench1,Stamp1),
+	test_set_wrench(test:'Fred',Wrench2,Stamp2),
+	%%
+	test_get_wrench(test:'Fred',Stamp0,Wrench0),
+	test_get_wrench(test:'Fred',Stamp01,Wrench0),
+	test_get_wrench(test:'Fred',Stamp1,Wrench1),
+	test_get_wrench(test:'Fred',Stamp2,Wrench2),
+	test_get_wrench(test:'Fred',Future,Wrench2).
+
+test('wrench_trajectory') :-
+	test_wrench_fred0(Wrench0,Stamp0),
+	test_wrench_fred1(Wrench1,Stamp1),
+	test_wrench_fred2(Wrench2,Stamp2),
+	test_trajectory(test:'Fred',Stamp0,Stamp2,
+		[Stamp0-Wrench0, Stamp1-Wrench1, Stamp2-Wrench2]),
+	test_trajectory(test:'Fred',Stamp1,Stamp2,
+		[Stamp1-Wrench1, Stamp2-Wrench2]).
+
+:- end_tests('wrench').

--- a/src/ros/wrench/wrench_mongo.pl
+++ b/src/ros/wrench/wrench_mongo.pl
@@ -1,0 +1,129 @@
+:- module(wrench_mongo,
+	[ wrench_mng_store/3,       % defined in wrench.cpp
+	  wrench_mng_lookup/6,
+	  wrench_mng_trajectory/4,
+	  wrench_mng_drop/0
+	]).
+
+:- use_foreign_library('libwrench_knowrob.so').
+
+:- use_module(library('semweb/rdf_db'),
+	[ rdf_split_url/3 ]).
+:- use_module(library('db/mongo/client')).
+
+% register wrench_raw/8 as a fluent predicate
+% FIXME: need to update collection name if collection prefix is changed
+:- mng_get_db(_DB, CollectionName, 'wrench'),
+   mongolog_add_fluent(wrench_raw,
+	   	% predicate arguments
+		[	+'header.frame_id'          % +Frame
+		,	-'wrench.force.x'           % -FX
+		,	-'wrench.force.y'           % -FY
+		,	-'wrench.force.z'           % -FZ
+		,	-'wrench.torque.x'          % -TX
+		,	-'wrench.torque.y'          % -TY
+		,	-'wrench.torque.z'          % -TZ
+		],
+   		% time field
+   		'header.stamp',
+		% options
+		[	collection(CollectionName)
+		]).
+
+% add *wrench* as a mongolog command such that it can be
+% used in mongolog queries.
+:- mongolog:add_command(wrench).
+
+% wrench/3
+lang_query:step_expand(
+		wrench(Frame, [FX,FY,FZ], [TX,TY,TZ]),
+		wrench_raw(Frame, FX, FY, FZ, TX, TY, TZ)).
+
+lang_query:step_expand(
+		assert(wrench(Frame, [FX,FY,FZ], [TX,TY,TZ])),
+		assert(wrench_raw(Frame, FX, FY, FZ, TX, TY, TZ))).
+
+% wrench/2
+lang_query:step_expand(
+		wrench(Frame, [[FX,FY,FZ], [TX,TY,TZ]]),
+		wrench_raw(Frame, FX, FY, FZ, TX, TY, TZ)).
+
+lang_query:step_expand(
+		assert(wrench(Frame, [[FX,FY,FZ], [TX,TY,TZ]])),
+		assert(wrench_raw(Frame, FX, FY, FZ, TX, TY, TZ))).
+
+%%
+wrench_db(DB, Name) :-
+	mng_get_db(DB, Name, 'wrench').
+
+%% wrench_mng_drop is det.
+%
+% Drops all documents in the wrench database collection.
+%
+wrench_mng_drop :-
+	wrench_db(DB, Name),
+	mng_drop(DB,Name).
+
+%% wrench_mng_lookup(+ObjFrame, +QuerySince, +QueryUntil, -PoseData, -FactSince, -FactUntil) is nondet.
+%
+% Retrieve all transforms of frame within some time interval.
+%
+wrench_mng_lookup(
+		ObjFrame, Query_Since, Query_Until,
+		WrenchData, Fact_Since, Fact_Until) :-
+	% create a query scope
+	time_scope(=<(Query_Since), >=(Query_Until), QueryScope),
+	mongolog_call(
+		wrench(ObjFrame, WrenchData),
+		[ scope(QueryScope),
+		  user_vars([['v_scope',FactScope]])
+		]),
+	% read values from FactScope
+	time_scope(double(Fact_Since), double(Fact_Until), FactScope).
+
+%% wrench_mng_lookup(+ObjFrame, -PoseData) is nondet.
+%
+% Retrieve the latest transform of a frame.
+%
+wrench_mng_lookup(ObjFrame, WrenchData) :-
+	get_time(Now),
+	wrench_mng_lookup(ObjFrame, Now, Now, WrenchData, _, _).
+
+%% wrench_mng_store(+ObjFrame, +PoseData, +Stamp) is det.
+%
+% Store a transform in mongo DB.
+%
+% Defined in wrench.cpp
+
+
+% % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
+% % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % % %
+% % % % % trajectories
+
+%% wrench_mng_trajectory(+Obj, +Begin, +End, -Trajectory) is det.
+%
+% Read all transforms associated to a frame in given time interval.
+%
+wrench_mng_trajectory(Obj,Stamp0,Stamp1,Trajectory) :-
+	rdf_split_url(_,ObjFrame,Obj),
+	findall(Stamp-Data,
+		( wrench_mng_lookup(ObjFrame,Stamp0,Stamp1,Data,Stamp,_),
+		  Stamp >= Stamp0,
+		  Stamp =< Stamp1
+		),
+		Trajectory0
+	),
+	reverse(Trajectory0,Trajectory).
+
+
+%%
+% Convert mongo document to wrench term.
+%
+wrench_mng_doc_pose(Doc,ObjFrame,Time,[[FX,FY,FZ],[TX,TY,TZ]]) :-
+	get_dict(header,Doc,
+		[ _, stamp-time(Time), frame_id-string(ObjFrame) ]
+	),
+	get_dict(transform,Doc,[
+		translation-[ x-double(FX), y-double(FY), z-double(FZ) ],
+		rotation-[ x-double(TX), y-double(TY), z-double(TZ) ]
+	]).

--- a/src/utility/filesystem.pl
+++ b/src/utility/filesystem.pl
@@ -2,7 +2,8 @@
     [ path_delimiter/1,
       path_concat/3,
       path_split/2,
-      mkdir/1
+      mkdir/1,
+      listdir/2
     ]).
 /** <module> Interacting with the filesystem.
 
@@ -63,3 +64,11 @@ mkdir(Path, [Head|Tail]) :-
   path_concat(Path, Head, ChildPath),
   mkdir(ChildPath, Tail).
 mkdir(_, []).
+
+%% listdir(+Dir, ?Entries)
+%
+% Get the contents of Dir without '.' and '..'
+listdir(Dir, Entries) :-
+  directory_files(Dir, Entries0),
+  delete(Entries0, '.', Entries1),
+  delete(Entries1, '..', Entries).


### PR DESCRIPTION
Add support for storing and loading subsymbolic data about wrenches
(forces & torques) acting on objects. This works exactly like the
mechanism for loading and storing /tf.

Right now, wrench data is always defined in the local coordinate
system of the object they act on and cannot be transformed by KnowRob.