### PR TITLE
Temporary fix: moved urdf_init to launch file, to avoid possible deadlock

### DIFF
--- a/launch/knowrob.launch
+++ b/launch/knowrob.launch
@@ -5,6 +5,6 @@
   
   <include file="$(find rosprolog)/launch/rosprolog.launch">
     <arg name="initial_package" default="knowrob" />
-    <arg name="initial_goal" default="true" />
+    <arg name="initial_goal" default="urdf_init" />
   </include>
 </launch>

--- a/src/ros/urdf/__init__.pl
+++ b/src/ros/urdf/__init__.pl
@@ -1,3 +1,5 @@
 
 :- use_module('URDF').
-:- urdf_init.
+% TODO: Calling urdf_init here leads to a deadlock
+% on SWI-Prolog >8.4. Moved it to launch file as temporary solution
+%:- urdf_init.


### PR DESCRIPTION
Since the update to SWI-Prolog v.8.4 KnowRob can be started using roslaunch. This is because of a potential deadlock when asking queries in the startup. The problem is the urdf_init call, which I moved to the launch file as a hotfix. 