### PR TITLE
Noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We have prepared different *.rosinstall* setup files that you can add to your RO
 rosdep update
 cd ~/catkin_ws/src
 wstool init
-wstool merge https://raw.github.com/knowrob/knowrob/master/rosinstall/knowrob-base.rosinstall
+wstool merge https://raw.github.com/hawkina/knowrob/noetic/rosinstall/knowrob-base.rosinstall
 wstool update
 rosdep install --ignore-src --from-paths .
 cd ~/catkin_ws

--- a/rosinstall/knowrob-base.rosinstall
+++ b/rosinstall/knowrob-base.rosinstall
@@ -1,3 +1,3 @@
-- git: {local-name: knowrob, uri: 'https://github.com/knowrob/knowrob.git', version: noetic }
+- git: {local-name: knowrob, uri: 'https://github.com/hawkina/knowrob.git', version: noetic }
 - git: {local-name: rosprolog, uri: 'https://github.com/knowrob/rosprolog.git', version: noetic }
 - git: {local-name: iai_common_msgs, uri: 'https://github.com/code-iai/iai_common_msgs.git', version: master }

--- a/rosinstall/knowrob-base.rosinstall
+++ b/rosinstall/knowrob-base.rosinstall
@@ -1,3 +1,3 @@
-- git: {local-name: knowrob, uri: 'https://github.com/knowrob/knowrob.git', version: master }
-- git: {local-name: rosprolog, uri: 'https://github.com/knowrob/rosprolog.git', version: master }
+- git: {local-name: knowrob, uri: 'https://github.com/knowrob/knowrob.git', version: noetic }
+- git: {local-name: rosprolog, uri: 'https://github.com/knowrob/rosprolog.git', version: noetic }
 - git: {local-name: iai_common_msgs, uri: 'https://github.com/code-iai/iai_common_msgs.git', version: master }


### PR DESCRIPTION
Hi
I've set rosprolog to pull from the noetic branch instead of master since otherwise it causes errors and the workspace won't compile. In the rosinstall it is set to my fork now of knowrob so that the installation instructions would work. It would be nice if we could have a noetic branch or a noetic rosinstall where the correct version of rosprolog is pulled :)
