### PR TITLE
Switched to current SOMA version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(knowrob)
 
-set(SOMA_VERSION "1.1.0")
+set(SOMA_VERSION "current")
 
 # include additional CMake macros
 include("cmake/ontologies.cmake")


### PR DESCRIPTION
After removing IOLite we would get an error while starting Knowrob, because v. 1.1.0 still imports IOLite. This fixes the bug, because the current version doesn't contain iolite.

We should fix a release after the next release of SOMA.