### PR TITLE
Fix DUL Prefix

### DIFF
--- a/src/model/DUL.pl
+++ b/src/model/DUL.pl
@@ -73,7 +73,7 @@ for modeling physical and social contexts.
 
 % load RDF data
 :- load_owl('http://www.ease-crc.org/ont/DUL.owl',
-	[ namespace(dul) ]).
+	[ namespace(dul,'http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#') ]).
 
 %% is_object(?Entity) is nondet.
 %


### PR DESCRIPTION
The prefix is broken, because load_owl takes the given URL if no prefix is explicitly stated. For DUL this URL is now a link to a copy on our server. Therefore we have explicitly add the real DUL prefix.