### PR TITLE
Fix to has_kinematics_file and map.launch

### DIFF
--- a/launch/map.launch
+++ b/launch/map.launch
@@ -1,14 +1,15 @@
 <launch>
   <arg name="knowrob_settings" default="$(find knowrob)/settings/default.pl" />
   <arg name="owl_file" default="package://knowrob/owl/robots/PR2.owl" />
-  <arg name="urdf_file" default="package://knowrob/urdf/pr2_for_unit_tests.urdf" />
+  <arg name="urdf_file" default="package://knowrob/urdf/pr2.urdf" />
   <arg name="object_iri" default="http://knowrob.org/kb/PR2.owl#PR2_0" />
+  <param name="mongodb_uri" value="$(optenv KNOWROB_MONGODB_URI mongodb://localhost:27017/?appname=knowrob)" />
   
   <!-- Configure settings file. -->
   <env name="KNOWROB_SETTINGS" value="$(arg knowrob_settings)" />
   
   <include file="$(find rosprolog)/launch/rosprolog.launch">
     <arg name="initial_package" default="knowrob" />
-    <arg name="initial_goal" default="load_owl('$(arg owl_file)'), urdf_load('$(arg object_iri)', '$(arg urdf_file)', [load_rdf]), urdf_set_pose_to_origin('$(arg object_iri)',map), sleep(1.0), marker:republish" />
+    <arg name="initial_goal" default="urdf_init, load_owl('$(arg owl_file)'), urdf_load('$(arg object_iri)', '$(arg urdf_file)', [load_rdf]), urdf_set_pose_to_origin('$(arg object_iri)',map), sleep(1.0), marker:republish" />
   </include>
 </launch>

--- a/src/model/SOMA.pl
+++ b/src/model/SOMA.pl
@@ -327,9 +327,9 @@ is_kino_dynamic_data(IO) ?+>
 %
 has_kinematics_file(Obj,Identifier,Format) +>
 	new_iri(IO,soma:'KinoDynamicData'),
-	new_iri(IR,io:'DigitalResource'),
+	new_iri(IR,soma:'DigitalResource'),
 	has_type(IO,soma:'KinoDynamicData'),
-	has_type(IR,io:'DigitalResource'),
+	has_type(IR,soma:'DigitalResource'),
 	triple(IO, dul:isAbout, Obj),
 	triple(IR, dul:realizes, IO),
 	triple(IR, soma:hasPersistentIdentifier, Identifier),


### PR DESCRIPTION
has_kinematics_file was throwing errors of the type

`[ WARN] [1657120958.483273528]: error(type_error(text,io:DigitalResource),context(system:atomic_list_concat/2,_38)).
`

The reason for this was that io: is not an valid namespace after removing the loading of iolite. We changed the prefix to the SOMA uri for the relevant concepts in the PR: https://github.com/ease-crc/soma/pull/273
Therefore I change the io: prefix to the soma: prefix.

This PR also contains minor fixes to the map.launch, so that we can use it again to visualize the robot. I added urdf_init to the initial calls and added the mongodb_uri (I copied this changes from the knowrob.launch). 