### PR TITLE
Work on URDF handling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN /usr/bin/python /opt/ros/melodic/bin/catkin_init_workspace
 
 RUN if [ "x$LOCAL_BUILD" = "x0" ] ; then \
     rm -rf /home/ros/src/* && \
-    git clone -b urdf-wip https://github.com/daniel86/knowrob.git && \
+    git clone https://github.com/knowrob/knowrob.git && \
     git clone https://github.com/knowrob/rosprolog.git && \
     git clone https://github.com/code-iai/iai_maps.git && \
     git clone https://github.com/code-iai/iai_common_msgs.git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN /usr/bin/python /opt/ros/melodic/bin/catkin_init_workspace
 
 RUN if [ "x$LOCAL_BUILD" = "x0" ] ; then \
     rm -rf /home/ros/src/* && \
-    git clone https://github.com/knowrob/knowrob.git && \
+    git clone -b urdf-wip https://github.com/daniel86/knowrob.git && \
     git clone https://github.com/knowrob/rosprolog.git && \
     git clone https://github.com/code-iai/iai_maps.git && \
     git clone https://github.com/code-iai/iai_common_msgs.git && \

--- a/launch/apartment.launch
+++ b/launch/apartment.launch
@@ -10,6 +10,6 @@
   
   <include file="$(find rosprolog)/launch/rosprolog.launch">
     <arg name="initial_package" default="knowrob" />
-    <arg name="initial_goal" default="urdf_init, load_owl('$(arg owl_file)'), urdf_load('$(arg object_iri)', '$(arg urdf_file)', [load_rdf]), urdf_set_pose_to_origin('$(arg object_iri)',map), sleep(1.0), marker:republish" />
+    <arg name="initial_goal" default="rdf_db:rdf_register_ns(iai_apartment, 'http://knowrob.org/kb/iai-apartment.owl#', [keep(true)]),urdf_init, load_owl('$(arg owl_file)'), urdf_load('$(arg object_iri)', '$(arg urdf_file)', [load_rdf]), urdf_set_pose_to_origin('$(arg object_iri)',map), sleep(1.0), marker:republish" />
   </include>
 </launch>

--- a/launch/apartment.launch
+++ b/launch/apartment.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="knowrob_settings" default="$(find knowrob)/settings/default.pl" />
   <arg name="owl_file" default="package://iai_apartment/owl/iai-apartment.owl" />
-  <arg name="urdf_file" default="package://iai_apartment/urdf/iai-apartment.urdf" />
+  <arg name="urdf_file" default="package://iai_apartment/urdf/apartment.urdf" />
   <arg name="object_iri" default="http://knowrob.org/kb/iai-apartment.owl#apartment_root" />
   <param name="mongodb_uri" value="$(optenv KNOWROB_MONGODB_URI mongodb://localhost:27017/?appname=knowrob)" />
   

--- a/owl/URDF.owl
+++ b/owl/URDF.owl
@@ -274,29 +274,6 @@
         <rdfs:range rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#array_double"/>
         <rdfs:label>has axis vector</rdfs:label>
     </owl:DatatypeProperty>
-
-    
-
-
-    <!-- http://knowrob.org/kb/urdf.owl#hasBaseLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/urdf.owl#hasBaseLinkName">
-        <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasNameString"/>
-        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:label>has base link name</rdfs:label>
-    </owl:DatatypeProperty>
-    
-
-
-    <!-- http://knowrob.org/kb/urdf.owl#hasEndLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/urdf.owl#hasEndLinkName">
-        <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasNameString"/>
-        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:label>has end link name</rdfs:label>
-    </owl:DatatypeProperty>
     
 
 

--- a/owl/robots/PR2.owl
+++ b/owl/robots/PR2.owl
@@ -124,19 +124,6 @@
     //
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
-
-    
-
-
-    <!-- http://knowrob.org/kb/srdl2-comp.owl#hasBaseLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/srdl2-comp.owl#hasBaseLinkName"/>
-    
-
-
-    <!-- http://knowrob.org/kb/srdl2-comp.owl#hasEndLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/srdl2-comp.owl#hasEndLinkName"/>
     
 
 
@@ -155,24 +142,6 @@
     <!-- http://knowrob.org/kb/srdl2-comp.owl#hasPayloadValue -->
 
     <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/srdl2-comp.owl#hasPayloadValue"/>
-    
-
-
-    <!-- http://knowrob.org/kb/urdf.owl#hasBaseLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/urdf.owl#hasBaseLinkName"/>
-    
-
-
-    <!-- http://knowrob.org/kb/urdf.owl#hasEndLinkName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/urdf.owl#hasEndLinkName"/>
-    
-
-
-    <!-- http://knowrob.org/kb/urdf.owl#hasURDFName -->
-
-    <owl:DatatypeProperty rdf:about="http://knowrob.org/kb/urdf.owl#hasURDFName"/>
     
 
 
@@ -226,6 +195,7 @@
 
     <owl:Class rdf:about="http://knowrob.org/kb/PR2.owl#PR2EnvironmentCamera">
         <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/srdl2-comp.owl#StereoCamera"/>
+        <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/urdf.owl#Link"/>
     </owl:Class>
     
 
@@ -270,6 +240,7 @@
 
     <owl:Class rdf:about="http://knowrob.org/kb/PR2.owl#PR2GripperAccelerometer">
         <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/srdl2-comp.owl#Accelerometer"/>
+        <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/urdf.owl#Link"/>
         <rdfs:comment>A three-axis accelerometer.</rdfs:comment>
     </owl:Class>
     
@@ -308,6 +279,7 @@
 
     <owl:Class rdf:about="http://knowrob.org/kb/PR2.owl#PR2Kinect">
         <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/srdl2-comp.owl#Kinect"/>
+        <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/urdf.owl#Link"/>
     </owl:Class>
     
 
@@ -316,6 +288,7 @@
 
     <owl:Class rdf:about="http://knowrob.org/kb/PR2.owl#PR2ManipulationCamera">
         <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/srdl2-comp.owl#StereoCamera"/>
+        <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/urdf.owl#Link"/>
     </owl:Class>
     
 
@@ -332,6 +305,7 @@
 
     <owl:Class rdf:about="http://knowrob.org/kb/PR2.owl#PR2Wheel">
         <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/srdl2-comp.owl#OmniWheel"/>
+        <rdfs:subClassOf rdf:resource="http://knowrob.org/kb/urdf.owl#Link"/>
     </owl:Class>
     
 
@@ -460,9 +434,7 @@
 
     <!-- http://knowrob.org/kb/srdl2-comp.owl#PerceptualAgent -->
 
-    <owl:Class rdf:about="http://knowrob.org/kb/srdl2-comp.owl#PerceptualAgent">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalAgent"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://knowrob.org/kb/srdl2-comp.owl#PerceptualAgent"/>
     
 
 
@@ -577,9 +549,9 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Arm_0_L">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Arm"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_shoulder_pan_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_forearm_cam_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_wrist_roll_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_shoulder_pan_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_forearm_cam_optical_frame"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_wrist_roll_link"/>
     </owl:NamedIndividual>
     
 
@@ -588,19 +560,9 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Arm_0_R">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Arm"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_shoulder_pan_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_forearm_cam_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_wrist_roll_link</urdf:hasEndLinkName>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://knowrob.org/kb/PR2.owl#PR2BackPlate_0 -->
-
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2BackPlate_0">
-        <rdf:type rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalArtifact"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">base_bellow_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">base_bellow_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_shoulder_pan_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_forearm_cam_optical_frame"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_wrist_roll_link"/>
     </owl:NamedIndividual>
     
 
@@ -609,23 +571,15 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Base_0">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Base"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_bll"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_blr"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brl"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brr"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_fll"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_flr"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frl"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frr"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">base_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bl_caster_l_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bl_caster_r_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">br_caster_l_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">br_caster_r_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fl_caster_l_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fl_caster_r_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fr_caster_l_wheel_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fr_caster_r_wheel_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#base_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#bl_caster_l_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#bl_caster_r_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#br_caster_l_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#br_caster_r_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#fl_caster_l_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#fl_caster_r_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#fr_caster_l_wheel_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#fr_caster_r_wheel_link"/>
     </owl:NamedIndividual>
     
 
@@ -634,8 +588,8 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LL">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_l_finger_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_l_finger_tip_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_l_finger_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_l_finger_tip_link"/>
     </owl:NamedIndividual>
     
 
@@ -644,8 +598,8 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LR">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_r_finger_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_r_finger_tip_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_r_finger_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_r_finger_tip_link"/>
     </owl:NamedIndividual>
     
 
@@ -654,8 +608,8 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RL">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_l_finger_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_l_finger_tip_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_l_finger_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_l_finger_tip_link"/>
     </owl:NamedIndividual>
     
 
@@ -664,8 +618,8 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RR">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_r_finger_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_r_finger_tip_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_r_finger_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_r_finger_tip_link"/>
     </owl:NamedIndividual>
     
 
@@ -674,16 +628,10 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Gripper_0_L">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Gripper"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LL"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LR"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_l"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_palm_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_l_finger_tip_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_led_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_motor_accelerometer_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_motor_screw_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_r_finger_tip_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_tool_frame</urdf:hasEndLinkName>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LL"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_LR"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_motor_accelerometer_link"/>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#l_gripper_palm_link"/>
     </owl:NamedIndividual>
     
 
@@ -692,16 +640,10 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Gripper_0_R">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Gripper"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RL"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RR"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_r"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_palm_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_l_finger_tip_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_led_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_motor_accelerometer_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_motor_screw_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_r_finger_tip_link</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_tool_frame</urdf:hasEndLinkName>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RL"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Finger_0_RR"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_motor_accelerometer_link"/>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#r_gripper_palm_link"/>
     </owl:NamedIndividual>
     
 
@@ -710,21 +652,11 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Head_0">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Head"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_EnvironmentCamera"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_Kinect"/>
-        <dul:hasPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2_0_ManipulationCamera"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head_pan_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head_mount_kinect_ir_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head_mount_kinect_rgb_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head_mount_prosilica_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">high_def_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narrow_stereo_l_stereo_camera_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narrow_stereo_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narrow_stereo_r_stereo_camera_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">projector_wg6802418_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wide_stereo_l_stereo_camera_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wide_stereo_optical_frame</urdf:hasEndLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wide_stereo_r_stereo_camera_optical_frame</urdf:hasEndLinkName>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#head_mount_link"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#narrow_stereo_optical_frame"/>
+        <SOMA:hasPhysicalComponent rdf:resource="http://knowrob.org/kb/PR2.owl#wide_stereo_optical_frame"/>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#head_pan_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#sensor_mount_link"/>
     </owl:NamedIndividual>
     
 
@@ -733,8 +665,8 @@
 
     <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2Neck_0">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Neck"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">torso_lift_link</urdf:hasBaseLinkName>
-        <urdf:hasEndLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">laser_tilt_link</urdf:hasEndLinkName>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#torso_lift_link"/>
+        <urdf:hasEndLink rdf:resource="http://knowrob.org/kb/PR2.owl#laser_tilt_link"/>
     </owl:NamedIndividual>
     
 
@@ -746,131 +678,118 @@
         <srdl2-cap:hasCapability rdf:resource="http://knowrob.org/kb/PR2.owl#VisualPerceptionCapability_1"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Arm_0_L"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Arm_0_R"/>
-        <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2BackPlate_0"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Base_0"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Gripper_0_L"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Gripper_0_R"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Head_0"/>
         <srdl2-comp:hasBodyPart rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Neck_0"/>
+        <urdf:hasBaseLink rdf:resource="http://knowrob.org/kb/PR2.owl#base_link"/>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_EnvironmentCamera -->
+    <!-- http://knowrob.org/kb/PR2.owl#wide_stereo_optical_frame -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_EnvironmentCamera">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#wide_stereo_optical_frame">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2EnvironmentCamera"/>
         <srdl2-cap:hasCapability rdf:resource="http://knowrob.org/kb/PR2.owl#VisualPerceptionCapability_1"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wide_stereo_optical_frame</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_l -->
+    <!-- http://knowrob.org/kb/PR2.owl#l_gripper_motor_accelerometer_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_l">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#l_gripper_motor_accelerometer_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2GripperAccelerometer"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l_gripper_motor_accelerometer_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_r -->
+    <!-- http://knowrob.org/kb/PR2.owl#r_gripper_motor_accelerometer_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_GripperAccelerometer_r">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#r_gripper_motor_accelerometer_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2GripperAccelerometer"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r_gripper_motor_accelerometer_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Kinect -->
+    <!-- http://knowrob.org/kb/PR2.owl#head_mount_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Kinect">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#head_mount_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Kinect"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head_mount_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_ManipulationCamera -->
+    <!-- http://knowrob.org/kb/PR2.owl#narrow_stereo_optical_frame -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_ManipulationCamera">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#narrow_stereo_optical_frame">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2ManipulationCamera"/>
         <srdl2-cap:hasCapability rdf:resource="http://knowrob.org/kb/PR2.owl#VisualPerceptionCapability_1"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narrow_stereo_optical_frame</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_bll -->
+    <!-- http://knowrob.org/kb/PR2.owl#bl_caster_l_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_bll">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#bl_caster_l_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bl_caster_l_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_blr -->
+    <!-- http://knowrob.org/kb/PR2.owl#bl_caster_r_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_blr">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#bl_caster_r_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bl_caster_r_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brl -->
+    <!-- http://knowrob.org/kb/PR2.owl#br_caster_l_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brl">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#br_caster_l_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">br_caster_l_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brr -->
+    <!-- http://knowrob.org/kb/PR2.owl#br_caster_r_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_brr">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#br_caster_r_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">br_caster_r_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_fll -->
+    <!-- http://knowrob.org/kb/PR2.owl#fl_caster_l_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_fll">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#fl_caster_l_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fl_caster_l_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_flr -->
+    <!-- http://knowrob.org/kb/PR2.owl#fl_caster_r_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_flr">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#fl_caster_r_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fl_caster_r_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frl -->
+    <!-- http://knowrob.org/kb/PR2.owl#fr_caster_l_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frl">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#fr_caster_l_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fr_caster_l_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 
 
-    <!-- http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frr -->
+    <!-- http://knowrob.org/kb/PR2.owl#fr_caster_r_wheel_link -->
 
-    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#PR2_0_Wheel_frr">
+    <owl:NamedIndividual rdf:about="http://knowrob.org/kb/PR2.owl#fr_caster_r_wheel_link">
         <rdf:type rdf:resource="http://knowrob.org/kb/PR2.owl#PR2Wheel"/>
-        <urdf:hasBaseLinkName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fr_caster_r_wheel_link</urdf:hasBaseLinkName>
     </owl:NamedIndividual>
     
 

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -390,7 +390,14 @@ load_rdf_(URL, Triples) :-
 load_rdf_1(URL, Triples) :-
 	% load rdf data. *Triples* is a ist of
 	% `rdf(Subject, Predicate, Object)` terms.
-	load_rdf(URL, Triples, [blank_nodes(noshare)]).
+	load_rdf(URL, Triples, [blank_nodes(noshare), namespaces(NSList)]),
+	% TODO load namespaces
+	forall((member(NS=Prefix, NSList),atom(NS)), (
+		rdf_register_ns(NS, Prefix, [keep(true)]),
+		% TODO namespaces should be stored in the DB too.
+		% else they are lost after the first run of knowrob.
+		true
+	)).
 
 %%
 convert_rdf_(IRI, rdf(S,P,O), triple(S1,P,O2)) :-

--- a/src/ros/urdf/URDF.pl
+++ b/src/ros/urdf/URDF.pl
@@ -98,13 +98,13 @@ urdf_init(Object,Identifier) :-
 	path_concat(DATA_URL,Filename,URL),
 	% get XML data
 	(	http_get(URL,XML_data,[]) -> true
-	;	(	log_warn(urdf(download_failed(Object,URL))),
+	;	(	log_warning(urdf(download_failed(Object,URL))),
 			fail
 		)
 	),
 	% parse data
 	(	urdf_load_xml(Object,XML_data) -> true
-	;	(	log_warn(urdf(parsing_failed(Object,URL))),
+	;	(	log_warning(urdf(parsing_failed(Object,URL))),
 			fail
 		)
 	),
@@ -333,7 +333,7 @@ urdf_chain(Object,FromLink,ToLink,X) :-
 	(	urdf_chain1(Object,FromLink,ToLink,Chain)
 	->	member(X,Chain)
 	;	(
-		log_warn(urdf(not_connnected(FromLink,ToLink))),
+		log_warning(urdf(not_connnected(FromLink,ToLink))),
 		X=FromLink
 	)).
 

--- a/src/ros/urdf/URDF.pl
+++ b/src/ros/urdf/URDF.pl
@@ -271,7 +271,8 @@ urdf_iri(Object,URDFPrefix,Name,IRI) :-
 	%             for link individuals!!
 	%%
 	rdf_split_url(IRIPrefix,_,Object),
-	atomic_list_concat([IRIPrefix,URDFPrefix,Name],'',IRI).
+	%atomic_list_concat([IRIPrefix,URDFPrefix,Name],'',IRI),
+	atomic_list_concat([IRIPrefix,Name],'',IRI).
 
 %%
 :- rdf_meta(joint_type_iri(?,r)).
@@ -320,14 +321,14 @@ create_joint_(Object,Prefix,Name,Joint) :-
 set_links_(Part,Prefix) :-
 	(	has_base_link_name(Part,BaseLinkName)
 	->	(	urdf_iri(Part,Prefix,BaseLinkName,BaseLink),
-			kb_project(has_base_link(Part,BaseLink))
+			(Part==BaseLink -> true ; kb_project(has_base_link(Part,BaseLink)))
 		)
 	;	true
 	),!,
 	forall(
 		has_end_link_name(Part,EndLinkName),
 		(	urdf_iri(Part,Prefix,EndLinkName,EndLink),
-			kb_project(has_end_link(Part,EndLink))
+			(Part==EndLink -> true ; kb_project(has_end_link(Part,EndLink)))
 		)
 	).
 

--- a/src/ros/urdf/URDF.pl
+++ b/src/ros/urdf/URDF.pl
@@ -208,12 +208,13 @@ urdf_set_pose_to_origin(Object,Frame) :-
 % @param Pose A pose list of frame-position-quaternion
 %
 urdf_pose(Object, ObjectFrame, Pose) :-
+	has_urdf(Object, URDFObject),
 	has_base_link_name(Object, LinkName),
-	(	has_urdf_prefix(Object, Prefix)
+	(	has_urdf_prefix(URDFObject, Prefix)
 	->	true
 	;	Prefix=''
 	),
-	urdf_pose1(Object, Prefix, LinkName, _, Pose),
+	urdf_pose1(URDFObject, Prefix, LinkName, _, Pose),
 	atom_concat(Prefix, LinkName, ObjectFrame).
 
 %% urdf_pose_abs(+Object, -ObjFrame, -AbsPose) is semidet.
@@ -226,25 +227,26 @@ urdf_pose(Object, ObjectFrame, Pose) :-
 % @param Pose A pose list of frame-position-quaternion
 %
 urdf_pose_abs(Object, ObjectFrame, AbsPose) :-
+	has_urdf(Object, URDFObject),
 	has_base_link_name(Object, LinkName),
-	(	has_urdf_prefix(Object, Prefix)
+	(	has_urdf_prefix(URDFObject, Prefix)
 	->	true
 	;	Prefix=''
 	),
-	urdf_pose1(Object, Prefix, LinkName, ParentName, RelPose),
-	urdf_pose_abs1(Object, Prefix, ParentName, RelPose, AbsPose),
+	urdf_pose1(URDFObject, Prefix, LinkName, ParentName, RelPose),
+	urdf_pose_abs1(URDFObject, Prefix, ParentName, RelPose, AbsPose),
 	atom_concat(Prefix, LinkName, ObjectFrame).
 
-urdf_pose1(Object, Prefix, LinkName, ParentName, [ParentFrame,Pos,Rot]) :-
-	%urdf_iri(Object, Prefix, LinkName, Link),
-	urdf_link_parent_joint(Object, LinkName, JointName),
-	urdf_joint_origin(Object, JointName, [_,Pos,Rot]),
-	urdf_joint_parent_link(Object, JointName, ParentName),
+urdf_pose1(URDFObject, Prefix, LinkName, ParentName, [ParentFrame,Pos,Rot]) :-
+	%urdf_iri(URDFObject, Prefix, LinkName, Link),
+	urdf_link_parent_joint(URDFObject, LinkName, JointName),
+	urdf_joint_origin(URDFObject, JointName, [_,Pos,Rot]),
+	urdf_joint_parent_link(URDFObject, JointName, ParentName),
 	atom_concat(Prefix, ParentName, ParentFrame).
 
-urdf_pose_abs1(Object, Prefix, ChildName,
+urdf_pose_abs1(URDFObject, Prefix, ChildName,
 		[ChildFrame,PosOX,RotOX], AbsPose) :-
-	urdf_pose1(Object, Prefix, ChildName,
+	urdf_pose1(URDFObject, Prefix, ChildName,
 		ParentName, [ParentFrame,PosXP,RotXP]),
 	!,
 	transform_multiply(
@@ -255,7 +257,7 @@ urdf_pose_abs1(Object, Prefix, ChildName,
 		% out: object pose relative to direct parent of x
 		[obj_frame, ParentFrame, PosOP, RotOP]
 	),
-	urdf_pose_abs1(Object, Prefix,
+	urdf_pose_abs1(URDFObject, Prefix,
 		ParentName, [ParentFrame, PosOP, RotOP],
 		AbsPose).
 


### PR DESCRIPTION
- removed hasBaseLinkName and hasEndLinkName properties from urdf.owl. only hasBaseLink and hasEndLink should be used in robot and environment owl files
- also removed predicates `has_base_link_name/2` and `has_end_link_name/2`
- convention: entities in the OWL can be classified as urdf:'Link', their name should in this case appear as a frame name in the associated URDF file
- for shapes it is needed that such urdf:'Link''s appear, and also that the component hierarchy is properly represented (in case individual objects within the urdf are displayed)
- added `urdf_pose` and `urdf_pose_rel` to read pose data from URDF file (used to show an object in base pose in openEASE)
- several smaller things, slightly more efficient database interaction