### PR TITLE
Fix mng import

### DIFF
--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -69,13 +69,20 @@ remember(Directory) :-
 
 %%
 mng_import(Dir) :-
-	forall(
-		(	collection_name(Name),
-			mng_get_db(DB, Collection, Name)
+	findall((DB, Dir0),
+		(	
+			collection_name(Name),
+			mng_get_db(DB, Collection, Name),
+			path_concat(Dir, Collection, Dir0),
+			exists_directory(Dir0)
 		),
-		(	path_concat(Dir, Collection, Dir0),
-			ignore(mng_restore(DB, Dir0))
-		)
+		DirCollection
+	),
+	% Fails if there is no directory to import
+	not(length(DirCollection, 0)),
+	forall(
+		member((DB1, Dir1), DirCollection),
+		mng_restore(DB1, Dir1)
 	).
 
 %% memorize(+Directory) is det.

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -74,7 +74,7 @@ mng_import(Dir) :-
 			mng_get_db(DB, Collection, Name)
 		),
 		(	path_concat(Dir, Collection, Dir0),
-			mng_restore(DB, Dir0)
+			ignore(mng_restore(DB, Dir0))
 		)
 	).
 


### PR DESCRIPTION
mng_import would return false if one of the collections doesn't exist in the directory to be imported. This fix will have mng_import return true as long as one collection to be imported exist. 