### PR TITLE
Fix mng_import

### DIFF
--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -40,7 +40,7 @@
 		'List of named graphs that should initially by erased.').
 
 %%
-:- setting(mng_client:collection_names, list, [triples, tf, annotations, inferred],
+:- setting(mng_client:collection_names, list, [triples, tf, annotations],
 		'List of collections that will be imported/exported with remember/memorize.').
 
 %%
@@ -78,11 +78,12 @@ mng_import(Dir) :-
 		),
 		DirCollection
 	),
+	writeln(DirCollection),
 	% Fails if there is no directory to import
 	not(length(DirCollection, 0)),
 	forall(
 		member((DB1, Dir1), DirCollection),
-		mng_restore(DB1, Dir1)
+		mng_restore(DB1, Dir1, Output)
 	).
 
 %% memorize(+Directory) is det.

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -78,7 +78,6 @@ mng_import(Dir) :-
 		),
 		DirCollection
 	),
-	writeln(DirCollection),
 	% Fails if there is no directory to import
 	not(length(DirCollection, 0)),
 	forall(

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -82,7 +82,7 @@ mng_import(Dir) :-
 	not(length(DirCollection, 0)),
 	forall(
 		member((DB1, Dir1), DirCollection),
-		mng_restore(DB1, Dir1, Output)
+		mng_restore(DB1, Dir1)
 	).
 
 %% memorize(+Directory) is det.

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -69,13 +69,20 @@ remember(Directory) :-
 
 %%
 mng_import(Dir) :-
-	forall(
-		(	collection_name(Name),
-			mng_get_db(DB, Collection, Name)
+	findall((DB, Dir0),
+		(	
+			collection_name(Name),
+			mng_get_db(DB, Collection, Name),
+			path_concat(Dir, Collection, Dir0),
+			exists_directory(Dir0)
 		),
-		(	path_concat(Dir, Collection, Dir0),
-			ignore(mng_restore(DB, Dir0))
-		)
+		DirCollection
+	),
+	% Fails if there is no directory to import
+	not(length(DirCollection, 0)),
+	forall(
+		member((DB1, Dir1), DirCollection),
+		mng_restore(DB1, Dir1)
 	).
 
 %% memorize(+Directory) is det.

--- a/src/lang/db.pl
+++ b/src/lang/db.pl
@@ -74,7 +74,7 @@ mng_import(Dir) :-
 			mng_get_db(DB, Collection, Name)
 		),
 		(	path_concat(Dir, Collection, Dir0),
-			mng_restore(DB, Dir0)
+			ignore(mng_restore(DB, Dir0))
 		)
 	).
 


### PR DESCRIPTION
mng_import would return false if one of the collections doesn't exist in the directory to be imported. This fix will have mng_import return true as long as one collection to be imported exist.

I also removed inferred from the default import list, because inferred isn't created automatically anymore.