### PR TITLE
bugfix: the expansion of ?> now correctly uses the current scope of the runtime

### DIFF
--- a/src/lang/query.pl
+++ b/src/lang/query.pl
@@ -789,8 +789,7 @@ user:term_expansion(
 	->	Export=[]
 	;	(
 		assertz(kb_predicate(Term1)),
-		current_scope(QScope),
-		Export=[(:-(Term1, lang_query:kb_call(Term1, QScope, _FScope, [])))]
+		Export=[(:-(Term1, lang_query:kb_call(Term1)))]
 	)).
 
 %%


### PR DESCRIPTION
Currently, the `?>` operator expands into a `kb_call` that contains the current scope at time of expansion.

This PR removes the scope and extra unused arguments to `kb_call` in the expansion so that `pred(Args) ?> ...` expands to `pred(Args) :- kb_call(pred(Args))`, which is more intuitive and which used the current scope at time of calling.

There is no difference in the unit tests and this should not break any existing behavior, and it removes the necessity to wrap calls in `kb_call` to use the current scope.