### PR TITLE
Testing infrastructure for complex queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,8 @@ endif()
 # flag for the linker.
 add_executable(all_gtests
 		tests/gtests.cpp
-		src/neems/test.cpp)
+		src/neems/test.cpp
+        tests/KnowledgeBaseTest.cpp)
 target_link_libraries(all_gtests
 		-Wl,--whole-archive,--no-as-needed
 		knowrob_qa

--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -109,6 +109,8 @@ namespace knowrob {
          */
         AnswerBufferPtr submitQuery(const FormulaPtr &query, int queryFlags);
 
+		auto& reasonerManager() const { return reasonerManager_; }
+
 	protected:
 		std::shared_ptr<ReasonerManager> reasonerManager_;
 		std::shared_ptr<KnowledgeGraphManager> backendManager_;

--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -48,6 +48,11 @@ namespace knowrob {
 	     */
 		explicit KnowledgeBase(const boost::property_tree::ptree &config);
 
+	    /**
+	     * @param configFile path to file that encodes a boost property tree used to configure the KB.
+	     */
+		explicit KnowledgeBase(const std::string_view &configFile);
+
         /**
          * Asserts a proposition into the knowledge base.
          * @param tripleData data representing the proposition.

--- a/include/knowrob/queries/QueryParser.h
+++ b/include/knowrob/queries/QueryParser.h
@@ -30,6 +30,8 @@ namespace knowrob {
 
         static TermPtr parseConstant(const std::string &queryString);
 
+        static std::string parseRawAtom(const std::string &queryString);
+
 	protected:
 		ParserRules *bnf_;
 	};

--- a/include/knowrob/terms/Substitution.h
+++ b/include/knowrob/terms/Substitution.h
@@ -68,6 +68,16 @@ namespace knowrob {
 		 * @return a term reference.
 		 */
 		const TermPtr& get(const Variable &var) const;
+
+		/**
+		 * Map the name of a variable to a term.
+		 * A null pointer reference is returned if the given variable
+		 * is not included in the mapping.
+		 *
+		 * @var a variable.
+		 * @return a term reference.
+		 */
+		const TermPtr& get(const std::string &varName) const;
 		
 		/**
 		 * Returns true if the given var is mapped to a term by this substitution.

--- a/src/KnowledgeBase.cpp
+++ b/src/KnowledgeBase.cpp
@@ -8,9 +8,12 @@
 
 #include <thread>
 #include <utility>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #include <knowrob/Logger.h>
 #include <knowrob/KnowledgeBase.h>
+#include <knowrob/URI.h>
 #include "knowrob/semweb/PrefixRegistry.h"
 #include "knowrob/queries/QueryParser.h"
 #include "knowrob/queries/QueryTree.h"
@@ -89,6 +92,17 @@ KnowledgeBase::KnowledgeBase(const boost::property_tree::ptree &config)
 {
 	backendManager_ = std::make_shared<KnowledgeGraphManager>(threadPool_);
 	reasonerManager_ = std::make_shared<ReasonerManager>(threadPool_, backendManager_);
+	loadConfiguration(config);
+}
+
+KnowledgeBase::KnowledgeBase(const std::string_view &configFile)
+: threadPool_(std::make_shared<ThreadPool>(std::thread::hardware_concurrency()))
+{
+	backendManager_ = std::make_shared<KnowledgeGraphManager>(threadPool_);
+	reasonerManager_ = std::make_shared<ReasonerManager>(threadPool_, backendManager_);
+
+	boost::property_tree::ptree config;
+	boost::property_tree::read_json(URI::resolve(configFile), config);
 	loadConfiguration(config);
 }
 

--- a/src/semweb/PrefixRegistry.cpp
+++ b/src/semweb/PrefixRegistry.cpp
@@ -4,75 +4,68 @@
 
 #include "knowrob/semweb/PrefixRegistry.h"
 #include "knowrob/semweb/PrefixProbe.h"
+#include "knowrob/Logger.h"
 
 using namespace knowrob::semweb;
 
-PrefixRegistry::PrefixRegistry()
-{
-    registerPrefix("owl",  "http://www.w3.org/2002/07/owl");
-    registerPrefix("rdf",  "http://www.w3.org/1999/02/22-rdf-syntax-ns");
-    registerPrefix("rdfs", "http://www.w3.org/2000/01/rdf-schema");
-    registerPrefix("xsd",  "http://www.w3.org/2001/XMLSchema");
-    registerPrefix("dul",  "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl");
+PrefixRegistry::PrefixRegistry() {
+	registerPrefix("owl", "http://www.w3.org/2002/07/owl");
+	registerPrefix("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns");
+	registerPrefix("rdfs", "http://www.w3.org/2000/01/rdf-schema");
+	registerPrefix("xsd", "http://www.w3.org/2001/XMLSchema");
+	registerPrefix("dul", "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl");
 }
 
-PrefixRegistry& PrefixRegistry::get()
-{
-    static PrefixRegistry singleton;
-    return singleton;
+PrefixRegistry &PrefixRegistry::get() {
+	static PrefixRegistry singleton;
+	return singleton;
 }
 
-void PrefixRegistry::registerPrefix(const std::string &prefix, const std::string &uri)
-{
-    if(uri[uri.size()-1]=='#') {
-        auto x = uri;
-        x.pop_back();
-        uriToAlias_[x] = prefix;
-        aliasToURI_[prefix] = x;
-    }
-    else {
-        uriToAlias_[uri] = prefix;
-        aliasToURI_[prefix] = uri;
-    }
+void PrefixRegistry::registerPrefix(const std::string &prefix, const std::string &uri) {
+	if (uri[uri.size() - 1] == '#') {
+		auto x = uri;
+		x.pop_back();
+		uriToAlias_[x] = prefix;
+		aliasToURI_[prefix] = x;
+		KB_INFO("registered alias {} -> {}", prefix, x);
+	} else {
+		uriToAlias_[uri] = prefix;
+		aliasToURI_[prefix] = uri;
+		KB_INFO("registered alias {} -> {}", prefix, uri);
+	}
 }
 
-OptionalStringRef PrefixRegistry::uriToAlias(const std::string &uri) const
-{
-    if(uri[uri.size()-1]=='#') {
-        auto x = uri;
-        x.pop_back();
-        auto it = uriToAlias_.find(x);
-        return it == uriToAlias_.end() ? std::nullopt : OptionalStringRef(it->second);
-    }
-    else {
-        auto it = uriToAlias_.find(uri);
-        return it == uriToAlias_.end() ? std::nullopt : OptionalStringRef(it->second);
-    }
+OptionalStringRef PrefixRegistry::uriToAlias(const std::string &uri) const {
+	if (uri[uri.size() - 1] == '#') {
+		auto x = uri;
+		x.pop_back();
+		auto it = uriToAlias_.find(x);
+		return it == uriToAlias_.end() ? std::nullopt : OptionalStringRef(it->second);
+	} else {
+		auto it = uriToAlias_.find(uri);
+		return it == uriToAlias_.end() ? std::nullopt : OptionalStringRef(it->second);
+	}
 }
 
-OptionalStringRef PrefixRegistry::aliasToUri(const std::string &alias) const
-{
-    auto it = aliasToURI_.find(alias);
-    return it == aliasToURI_.end() ? std::nullopt : OptionalStringRef(it->second);
+OptionalStringRef PrefixRegistry::aliasToUri(const std::string &alias) const {
+	auto it = aliasToURI_.find(alias);
+	return it == aliasToURI_.end() ? std::nullopt : OptionalStringRef(it->second);
 }
 
-std::optional<std::string> PrefixRegistry::createIRI(const std::string &alias, const std::string &entityName) const
-{
-    auto uri = aliasToUri(alias);
-    if(uri.has_value()) {
-        return uri.value().get() + "#" + entityName;
-    }
-    else {
-        return uri;
-    }
+std::optional<std::string> PrefixRegistry::createIRI(const std::string &alias, const std::string &entityName) const {
+	auto uri = aliasToUri(alias);
+	if (uri.has_value()) {
+		return uri.value().get() + "#" + entityName;
+	} else {
+		return uri;
+	}
 }
 
-std::vector<std::string_view> PrefixRegistry::getAliasesWithPrefix(const std::string &prefix) const
-{
-    auto range_it = aliasToURI_.equal_range(PrefixProbe { prefix });
-    std::vector<std::string_view> result;
-    for (auto it = range_it.first; it != range_it.second; ++it) {
-        result.emplace_back(it->first.c_str());
-    }
-    return result;
+std::vector<std::string_view> PrefixRegistry::getAliasesWithPrefix(const std::string &prefix) const {
+	auto range_it = aliasToURI_.equal_range(PrefixProbe{prefix});
+	std::vector<std::string_view> result;
+	for (auto it = range_it.first; it != range_it.second; ++it) {
+		result.emplace_back(it->first.c_str());
+	}
+	return result;
 }

--- a/src/terms/Substitution.cpp
+++ b/src/terms/Substitution.cpp
@@ -43,6 +43,11 @@ const TermPtr& Substitution::get(const Variable &var) const
 	}
 }
 
+const TermPtr& Substitution::get(const std::string &varName) const
+{
+	return get(Variable(varName));
+}
+
 size_t Substitution::computeHash() const
 {
     static const auto GOLDEN_RATIO_HASH = static_cast<size_t>(0x9e3779b9);

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -1,27 +1,34 @@
-
 #include <gtest/gtest.h>
 
-// fixture class for testing
-class KnowledgeBaseTest : public ::testing::Test {
-protected:
-    //static std::shared_ptr<KnoweldgeBase> kb_;
-    static void SetUpTestSuite() {
-        // setup, once called
-    }
-    // void TearDown() override {}
-    // add some helper functions below...
-};
+#include "KnowledgeBaseTest.h"
+
+using namespace knowrob;
+
+#define KB_TEST_SETTINGS_FILE "tests/settings/kb-test.json"
 
 // TODO:
 // here main interface of KnoweldgeBase should be tested, in particular:
 // - submitQuery*
 // - insert*
 //
-// what is needed:
-// - setup database backend for testing, insert tmp data on which queries can be evaluated
-// - generate an adhoc configuration for KnowledgeBase. currently this must be a boost property tree
+// what still is needed:
 // - use some dummy reasoner with fixed input-output mapping that can be tested easily
 //
+
+std::shared_ptr<knowrob::KnowledgeBase> KnowledgeBaseTest::kb_;
+
+void KnowledgeBaseTest::SetUpTestSuite() {
+	// initialize a KB, setup database backend for testing, insert tmp data on which queries can be evaluated
+	kb_ = std::make_shared<KnowledgeBase>(KB_TEST_SETTINGS_FILE);
+}
+
+void KnowledgeBaseTest::TearDown() {
+	resetDB();
+}
+
+void KnowledgeBaseTest::resetDB() {
+	// TODO delete all records that are stored in the DB.
+}
 
 TEST_F(KnowledgeBaseTest, ThisFails)
 {

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -1,0 +1,18 @@
+
+#include <gtest/gtest.h>
+
+// fixture class for testing
+class KnowledgeBaseTest : public ::testing::Test {
+protected:
+    //static std::shared_ptr<KnoweldgeBase> kb_;
+    static void SetUpTestSuite() {
+        // setup, once called
+    }
+    // void TearDown() override {}
+    // add some helper functions below...
+};
+
+TEST_F(KnowledgeBaseTest, ThisFails)
+{
+    EXPECT_EQ(1, 0);
+}

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -12,6 +12,17 @@ protected:
     // add some helper functions below...
 };
 
+// TODO:
+// here main interface of KnoweldgeBase should be tested, in particular:
+// - submitQuery*
+// - insert*
+//
+// what is needed:
+// - setup database backend for testing, insert tmp data on which queries can be evaluated
+// - generate an adhoc configuration for KnowledgeBase. currently this must be a boost property tree
+// - use some dummy reasoner with fixed input-output mapping that can be tested easily
+//
+
 TEST_F(KnowledgeBaseTest, ThisFails)
 {
     EXPECT_EQ(1, 0);

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -37,6 +37,19 @@ static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
 	return out;
 }
 
+static bool containsAnswer(const std::vector<SubstitutionPtr> &answers, const std::string &key, const TermPtr &value) {
+	Variable v_key(key);
+	for(auto x: answers) {
+		if(x->contains(v_key)) {
+			auto actual = x->get(v_key);
+			if(*value == *actual) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 TEST_F(KnowledgeBaseTest, undefinedNamespace) {
 	EXPECT_THROW(lookupAll("undefined:hasSibling(swrl_test:Fred, X)"), QueryError);
 }
@@ -48,4 +61,30 @@ TEST_F(KnowledgeBaseTest, atomic_EDB) {
 	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Lea, X)").size(), 0);
 	EXPECT_EQ(lookupAll("swrl_test:hasSibling(X, swrl_test:Ernest)").size(), 1);
 	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Fred, swrl_test:Ernest)").size(), 1);
+}
+
+TEST_F(KnowledgeBaseTest, conjunctive_EDB) {
+	const auto queryString = "swrl_test:hasSibling(swrl_test:Fred,X) , swrl_test:hasNumber(X,Num)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_EQ(*lookupAll(queryString)[0]->get("Num"), StringTerm("123456"));
+}
+
+TEST_F(KnowledgeBaseTest, disjunctive_EDB) {
+	const auto queryString = "swrl_test:hasSibling(swrl_test:Fred,X) ; swrl_test:hasAncestor(swrl_test:Fred,X)";
+	EXPECT_EQ(lookupAll(queryString).size(), 2);
+	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Ernest")));
+	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Rex")));
+}
+
+TEST_F(KnowledgeBaseTest, negated_EDB) {
+	const auto queryString = "~swrl_test:hasSibling(swrl_test:Lea,X)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_TRUE(lookupAll(queryString)[0]->empty());
+}
+
+TEST_F(KnowledgeBaseTest, complex_EDB) {
+	const auto queryString = "(swrl_test:hasSibling(swrl_test:Fred,X) ; "\
+							 "swrl_test:hasAncestor(swrl_test:Fred,X)) , swrl_test:hasSibling(X,Y)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Ernest")));
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "KnowledgeBaseTest.h"
+#include "knowrob/queries/QueryParser.h"
 
 using namespace knowrob;
 
@@ -22,15 +23,11 @@ void KnowledgeBaseTest::SetUpTestSuite() {
 	kb_ = std::make_shared<KnowledgeBase>(KB_TEST_SETTINGS_FILE);
 }
 
-void KnowledgeBaseTest::TearDown() {
-	resetDB();
-}
-
-void KnowledgeBaseTest::resetDB() {
-	// TODO delete all records that are stored in the DB.
-}
-
-TEST_F(KnowledgeBaseTest, ThisFails)
+TEST_F(KnowledgeBaseTest, atomic_EDB)
 {
+    auto answerStream = kb_->submitQuery(
+            QueryParser::parse("swrl_test:hasSibling(swrl_test:'Ernest', Sibling)"),
+            QUERY_FLAG_ALL_SOLUTIONS);
+    //auto q = answerStream->createQueue()->toArray();
     EXPECT_EQ(1, 0);
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -8,20 +8,78 @@ using namespace knowrob;
 
 #define KB_TEST_SETTINGS_FILE "tests/settings/kb-test.json"
 
-// TODO:
-// here main interface of KnoweldgeBase should be tested, in particular:
-// - submitQuery*
-// - insert*
-//
-// what still is needed:
-// - use some dummy reasoner with fixed input-output mapping that can be tested easily
-//
-
 std::shared_ptr<knowrob::KnowledgeBase> KnowledgeBaseTest::kb_;
+
+// a reasoner that defines a single fact
+class TestReasoner : public knowrob::Reasoner {
+public:
+	const std::string p_;
+	const std::string s_;
+	const std::string o_;
+	TestReasoner(const std::string_view &p, const std::string_view &s, const std::string_view &o)
+	: knowrob::Reasoner(), p_(p), s_(s), o_(o) {}
+
+	bool loadConfiguration(const ReasonerConfiguration &cfg) override { return true; }
+	void setDataBackend(const KnowledgeGraphPtr &knowledgeGraph) override {}
+	unsigned long getCapabilities() const override { return CAPABILITY_TOP_DOWN_EVALUATION; };
+
+	std::shared_ptr<PredicateDescription> getPredicateDescription(
+		const std::shared_ptr<PredicateIndicator> &indicator) override {
+		if(indicator->functor() == p_) {
+			return std::make_shared<PredicateDescription>(
+				std::make_shared<PredicateIndicator>(p_,2), PredicateType::RELATION);
+		}
+		else {
+			return {};
+		}
+	}
+
+	AnswerBufferPtr submitQuery(const RDFLiteralPtr &literal, int queryFlags) override {
+		auto answerBuffer = std::make_shared<AnswerBuffer>();
+		auto outputChannel = AnswerStream::Channel::create(answerBuffer);
+		auto answer = std::make_shared<Answer>();
+
+		bool succeed = true;
+		if(literal->propertyTerm()->isGround()) {
+			succeed = (*literal->propertyTerm() == StringTerm(p_));
+		}
+		if(literal->subjectTerm()->isGround()) {
+			succeed = succeed && (*literal->subjectTerm() == StringTerm(s_));
+		}
+		if(literal->objectTerm()->isGround()) {
+			succeed = succeed && (*literal->objectTerm() == StringTerm(o_));
+		}
+
+		if(succeed) {
+			if(!literal->propertyTerm()->isGround()) {
+				auto v = *literal->propertyTerm()->getVariables().begin();
+				answer->substitution()->set(*v, std::make_shared<StringTerm>(p_));
+			}
+			if(!literal->subjectTerm()->isGround()) {
+				auto v = *literal->subjectTerm()->getVariables().begin();
+				answer->substitution()->set(*v, std::make_shared<StringTerm>(s_));
+			}
+			if(!literal->objectTerm()->isGround()) {
+				auto v = *literal->objectTerm()->getVariables().begin();
+				answer->substitution()->set(*v, std::make_shared<StringTerm>(o_));
+			}
+			outputChannel->push(answer);
+		}
+
+		outputChannel->push(AnswerStream::eos());
+		return answerBuffer;
+	}
+};
 
 void KnowledgeBaseTest::SetUpTestSuite() {
 	// initialize a KB, setup database backend for testing, insert tmp data on which queries can be evaluated
 	kb_ = std::make_shared<KnowledgeBase>(KB_TEST_SETTINGS_FILE);
+
+	auto c1 = QueryParser::parseRawAtom("swrl_test:Ernest");
+	kb_->reasonerManager()->addReasoner(
+		"r1", std::make_shared<TestReasoner>("p", c1, "x"));
+	kb_->reasonerManager()->addReasoner(
+		"r2", std::make_shared<TestReasoner>("q", "x", "y"));
 }
 
 static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
@@ -39,14 +97,15 @@ static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
 
 static bool containsAnswer(const std::vector<SubstitutionPtr> &answers, const std::string &key, const TermPtr &value) {
 	Variable v_key(key);
-	for(auto x: answers) {
-		if(x->contains(v_key)) {
+	for (auto &x: answers) {
+		if (x->contains(v_key)) {
 			auto actual = x->get(v_key);
-			if(*value == *actual) {
+			if (*value == *actual) {
 				return true;
 			}
 		}
 	}
+
 	return false;
 }
 
@@ -63,6 +122,15 @@ TEST_F(KnowledgeBaseTest, atomic_EDB) {
 	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Fred, swrl_test:Ernest)").size(), 1);
 }
 
+TEST_F(KnowledgeBaseTest, modal_EDB) {
+	EXPECT_EQ(lookupAll("B swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+	EXPECT_EQ(*lookupAll("B swrl_test:hasSibling(swrl_test:Fred, X)")[0]->get("X"),
+	          *QueryParser::parseConstant("swrl_test:Ernest"));
+	EXPECT_EQ(lookupAll("K swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+	EXPECT_EQ(*lookupAll("K swrl_test:hasSibling(swrl_test:Fred, X)")[0]->get("X"),
+	          *QueryParser::parseConstant("swrl_test:Ernest"));
+}
+
 TEST_F(KnowledgeBaseTest, conjunctive_EDB) {
 	const auto queryString = "swrl_test:hasSibling(swrl_test:Fred,X) , swrl_test:hasNumber(X,Num)";
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
@@ -76,15 +144,22 @@ TEST_F(KnowledgeBaseTest, disjunctive_EDB) {
 	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Rex")));
 }
 
+TEST_F(KnowledgeBaseTest, complex_EDB) {
+	const auto queryString = "(swrl_test:hasSibling(swrl_test:Fred,X) ; "\
+							 "swrl_test:hasAncestor(swrl_test:Fred,X)) , swrl_test:hasSibling(X,Y)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Ernest")));
+}
+
 TEST_F(KnowledgeBaseTest, negated_EDB) {
 	const auto queryString = "~swrl_test:hasSibling(swrl_test:Lea,X)";
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
 	EXPECT_TRUE(lookupAll(queryString)[0]->empty());
 }
 
-TEST_F(KnowledgeBaseTest, complex_EDB) {
+TEST_F(KnowledgeBaseTest, negatedComplex_EDB) {
 	const auto queryString = "(swrl_test:hasSibling(swrl_test:Fred,X) ; "\
-							 "swrl_test:hasAncestor(swrl_test:Fred,X)) , swrl_test:hasSibling(X,Y)";
+		"swrl_test:hasAncestor(swrl_test:Fred,X)) , ~swrl_test:hasSibling(X,Y)";
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
-	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Ernest")));
+	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Rex")));
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -2,6 +2,7 @@
 
 #include "KnowledgeBaseTest.h"
 #include "knowrob/queries/QueryParser.h"
+#include "knowrob/queries/QueryError.h"
 
 using namespace knowrob;
 
@@ -23,11 +24,28 @@ void KnowledgeBaseTest::SetUpTestSuite() {
 	kb_ = std::make_shared<KnowledgeBase>(KB_TEST_SETTINGS_FILE);
 }
 
-TEST_F(KnowledgeBaseTest, atomic_EDB)
-{
-    auto answerStream = kb_->submitQuery(
-            QueryParser::parse("swrl_test:hasSibling(swrl_test:'Ernest', Sibling)"),
-            QUERY_FLAG_ALL_SOLUTIONS);
-    //auto q = answerStream->createQueue()->toArray();
-    EXPECT_EQ(1, 0);
+static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
+	auto answerStream = KnowledgeBaseTest::kb_->submitQuery(
+			QueryParser::parse(queryString), QUERY_FLAG_ALL_SOLUTIONS);
+	auto answerQueue = answerStream->createQueue();
+	std::vector<SubstitutionPtr> out;
+	while(true) {
+		auto solution = answerQueue->pop_front();
+		if(AnswerStream::isEOS(solution)) break;
+		out.push_back(solution->substitution());
+	}
+	return out;
+}
+
+TEST_F(KnowledgeBaseTest, undefinedNamespace) {
+	EXPECT_THROW(lookupAll("undefined:hasSibling(swrl_test:Fred, X)"), QueryError);
+}
+
+TEST_F(KnowledgeBaseTest, atomic_EDB) {
+	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+	EXPECT_EQ(*lookupAll("swrl_test:hasSibling(swrl_test:Fred, X)")[0]->get("X"),
+	          *QueryParser::parseConstant("swrl_test:Ernest"));
+	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Lea, X)").size(), 0);
+	EXPECT_EQ(lookupAll("swrl_test:hasSibling(X, swrl_test:Ernest)").size(), 1);
+	EXPECT_EQ(lookupAll("swrl_test:hasSibling(swrl_test:Fred, swrl_test:Ernest)").size(), 1);
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -163,3 +163,22 @@ TEST_F(KnowledgeBaseTest, negatedComplex_EDB) {
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
 	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Rex")));
 }
+
+TEST_F(KnowledgeBaseTest, atomic_IDB) {
+	EXPECT_EQ(lookupAll("p(swrl_test:Ernest, X)").size(), 1);
+	EXPECT_EQ(*lookupAll("p(swrl_test:Ernest, X)")[0]->get("X"), StringTerm("x"));
+	EXPECT_EQ(lookupAll("p(x, X)").size(), 0);
+	EXPECT_EQ(lookupAll("q(x, X)").size(), 1);
+}
+
+TEST_F(KnowledgeBaseTest, mixed_EDB_IDB) {
+	const auto queryString = "swrl_test:hasSibling(swrl_test:Fred,Ernest) , p(Ernest,Y)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_EQ(*lookupAll(queryString)[0]->get("Y"), StringTerm("x"));
+}
+
+TEST_F(KnowledgeBaseTest, IDB_interaction) {
+	const auto queryString = "p(Ernest,X) , q(X,Y)";
+	EXPECT_EQ(lookupAll(queryString).size(), 1);
+	EXPECT_EQ(*lookupAll(queryString)[0]->get("Y"), StringTerm("y"));
+}

--- a/tests/KnowledgeBaseTest.h
+++ b/tests/KnowledgeBaseTest.h
@@ -1,0 +1,19 @@
+//
+// Created by daniel on 21.11.23.
+//
+
+#ifndef KNOWROB_KNOWLEDGE_BASE_TEST_H
+#define KNOWROB_KNOWLEDGE_BASE_TEST_H
+
+#include "knowrob/KnowledgeBase.h"
+
+// fixture class for testing
+class KnowledgeBaseTest : public ::testing::Test {
+protected:
+    static std::shared_ptr<knowrob::KnowledgeBase> kb_;
+    static void SetUpTestSuite();
+    void TearDown() override;
+    void resetDB();
+};
+
+#endif //KNOWROB_KNOWLEDGE_BASE_TEST_H

--- a/tests/KnowledgeBaseTest.h
+++ b/tests/KnowledgeBaseTest.h
@@ -12,8 +12,7 @@ class KnowledgeBaseTest : public ::testing::Test {
 protected:
     static std::shared_ptr<knowrob::KnowledgeBase> kb_;
     static void SetUpTestSuite();
-    void TearDown() override;
-    void resetDB();
+    //void TearDown() override;
 };
 
 #endif //KNOWROB_KNOWLEDGE_BASE_TEST_H

--- a/tests/KnowledgeBaseTest.h
+++ b/tests/KnowledgeBaseTest.h
@@ -9,8 +9,9 @@
 
 // fixture class for testing
 class KnowledgeBaseTest : public ::testing::Test {
-protected:
+public:
     static std::shared_ptr<knowrob::KnowledgeBase> kb_;
+protected:
     static void SetUpTestSuite();
     //void TearDown() override;
 };

--- a/tests/settings/kb-test.json
+++ b/tests/settings/kb-test.json
@@ -1,0 +1,28 @@
+{
+  "logging": {
+    "console-sink": { "level": "debug" },
+    "file-sink": { "level": "debug" }
+  },
+  "semantic-web": {
+    "prefixes": [
+      { "alias": "swrl_test", "uri":  "http://knowrob.org/kb/swrl_test" }
+    ]
+  },
+  "data-sources": [
+    {
+      "path": "owl/test/swrl.owl",
+      "format": "rdf-xml"
+    }
+  ],
+  "data-backends": [
+    {
+      "type": "MongoDB",
+      "name": "mongodb",
+      "host": "localhost",
+      "port": 27017,
+      "db": "test",
+      "read-only": false
+    }
+  ],
+  "reasoner": []
+}


### PR DESCRIPTION
This change-set adds test cases for the `KnowledgeBase` class. The test cases only cover the `submitQuery` inteface. The assertions of new facts will be covered later. Summarizing this adds

- a test suite for the KB class
- better handling of namespaces in query parsing
- KB test cases for querying conjunctions, disjunctions, negations
- KB test cases for querying EDB and IDB predicates