### PR TITLE
Negation of statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,11 @@ add_library(knowrob_qa SHARED
         src/queries/GraphQuery.cpp
         src/queries/Query.cpp
         src/queries/RedundantAnswerFilter.cpp
+        src/queries/EDBStage.cpp
+        src/queries/QueryStage.cpp
+        src/queries/IDBStage.cpp
+        src/queries/QueryPipeline.cpp
+        src/queries/NegationStage.cpp
 		src/semweb/PrefixRegistry.cpp
         src/semweb/PrefixProbe.cpp
 		src/semweb/xsd.cpp
@@ -238,11 +243,7 @@ add_library(knowrob_qa SHARED
         src/modalities/ModalityLabel.cpp
         src/semweb/KnowledgeGraph.cpp
         src/semweb/KnowledgeGraphManager.cpp
-        src/semweb/KnowledgeGraphPlugin.cpp
-        src/queries/EDBStage.cpp
-        src/queries/QueryStage.cpp
-        src/queries/IDBStage.cpp
-        src/queries/QueryPipeline.cpp)
+        src/semweb/KnowledgeGraphPlugin.cpp)
 target_link_libraries(knowrob_qa
 		${SWIPL_LIBRARIES}
 		${MONGOC_LIBRARIES}

--- a/include/knowrob/formulas/Literal.h
+++ b/include/knowrob/formulas/Literal.h
@@ -41,6 +41,12 @@ namespace knowrob {
         auto isNegated() const { return isNegated_; }
 
         /**
+         * Set the negated flag of this literal.
+         * @param isNegated true indicates the literal is negated.
+         */
+        void setIsNegated(bool isNegated) { isNegated_ = isNegated; }
+
+        /**
          * Get the functor of this literal.
          *
          * @return the functor name.
@@ -75,7 +81,7 @@ namespace knowrob {
     protected:
         const PredicatePtr predicate_;
         const ModalityLabelPtr label_;
-        const bool isNegated_;
+        bool isNegated_;
     };
 
     using LiteralPtr = std::shared_ptr<Literal>;

--- a/include/knowrob/queries/AnswerBroadcaster.h
+++ b/include/knowrob/queries/AnswerBroadcaster.h
@@ -41,7 +41,7 @@ namespace knowrob {
 
 		// Override QueryResultStream
 		void push(const AnswerPtr &msg) override;
-		void pushToBroadcast(const AnswerPtr &msg);
+		virtual void pushToBroadcast(const AnswerPtr &msg);
 	};
 
     void operator>>(const std::shared_ptr<AnswerBroadcaster> &a,

--- a/include/knowrob/queries/NegationStage.h
+++ b/include/knowrob/queries/NegationStage.h
@@ -1,0 +1,31 @@
+//
+// Created by danielb on 23.11.23.
+//
+
+#ifndef KNOWROB_NEGATION_STAGE_H
+#define KNOWROB_NEGATION_STAGE_H
+
+#include "knowrob/semweb/RDFLiteral.h"
+#include "knowrob/reasoner/ReasonerManager.h"
+
+namespace knowrob {
+
+    class NegationStage : public AnswerBroadcaster {
+    public:
+        NegationStage(const std::shared_ptr<KnowledgeGraph> &kg,
+                      const std::shared_ptr<ReasonerManager> &reasonerManager,
+                      const std::vector<RDFLiteralPtr> &negativeLiterals);
+
+        bool succeeds(const AnswerPtr &answer);
+
+    protected:
+        std::shared_ptr<KnowledgeGraph> kg_;
+        std::shared_ptr<ReasonerManager> reasonerManager_;
+        const std::vector<RDFLiteralPtr> negativeLiterals_;
+
+        void pushToBroadcast(const AnswerPtr &msg) override;
+    };
+
+} // knowrob
+
+#endif //KNOWROB_NEGATION_STAGE_H

--- a/include/knowrob/queries/NegationStage.h
+++ b/include/knowrob/queries/NegationStage.h
@@ -9,22 +9,25 @@
 #include "knowrob/reasoner/ReasonerManager.h"
 
 namespace knowrob {
+	/**
+	 * A stage that evaluates a set of negations which are considered
+	 * in conjunction.
+	 */
+	class NegationStage : public AnswerBroadcaster {
+	public:
+		NegationStage(const std::shared_ptr<KnowledgeGraph> &kg,
+					  const std::shared_ptr<ReasonerManager> &reasonerManager,
+					  const std::vector<RDFLiteralPtr> &negativeLiterals);
 
-    class NegationStage : public AnswerBroadcaster {
-    public:
-        NegationStage(const std::shared_ptr<KnowledgeGraph> &kg,
-                      const std::shared_ptr<ReasonerManager> &reasonerManager,
-                      const std::vector<RDFLiteralPtr> &negativeLiterals);
+		bool succeeds(const AnswerPtr &answer);
 
-        bool succeeds(const AnswerPtr &answer);
+	protected:
+		std::shared_ptr<KnowledgeGraph> kg_;
+		std::shared_ptr<ReasonerManager> reasonerManager_;
+		const std::vector<RDFLiteralPtr> negativeLiterals_;
 
-    protected:
-        std::shared_ptr<KnowledgeGraph> kg_;
-        std::shared_ptr<ReasonerManager> reasonerManager_;
-        const std::vector<RDFLiteralPtr> negativeLiterals_;
-
-        void pushToBroadcast(const AnswerPtr &msg) override;
-    };
+		void pushToBroadcast(const AnswerPtr &msg) override;
+	};
 
 } // knowrob
 

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -30,14 +30,14 @@ bool NegationStage::succeeds(const AnswerPtr &answer) {
 	std::vector<AnswerBufferPtr> results;
 
 	for (auto &lit: negativeLiterals_) {
-		// create an instance of the literal based on given substitution
-		auto instance = RDFLiteral::fromLiteral(
-				lit->applySubstitution(*answer->substitution()));
-
+		auto lit1 = lit->applySubstitution(*answer->substitution());
 		// for now evaluate positive variant of the literal.
 		// NOTE: for open-world semantics this cannot be done. open-world reasoner
 		//       would need to receive negative literal instead.
-		instance->setIsNegated(false);
+		lit1->setIsNegated(false);
+
+		// create an instance of the literal based on given substitution
+		auto instance = RDFLiteral::fromLiteral(lit1);
 
 		// check if the EDB contains positive lit, if so negation cannot be true
 		results.push_back(kg_->submitQuery(
@@ -49,7 +49,7 @@ bool NegationStage::succeeds(const AnswerPtr &answer) {
 		std::vector<std::shared_ptr<Reasoner>> l_reasoner;
 		for (auto &pair: reasonerManager_->reasonerPool()) {
 			auto &r = pair.second->reasoner();
-			if (r->canEvaluate(*lit)) {
+			if (r->canEvaluate(*instance)) {
 				results.push_back(r->submitQuery(instance, QUERY_FLAG_ALL_SOLUTIONS));
 			}
 		}

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -1,0 +1,69 @@
+//
+// Created by danielb on 23.11.23.
+//
+
+#include "knowrob/queries/NegationStage.h"
+#include "knowrob/KnowledgeBase.h"
+
+using namespace knowrob;
+
+NegationStage::NegationStage(const std::shared_ptr<KnowledgeGraph> &kg,
+                             const std::shared_ptr<ReasonerManager> &reasonerManager,
+                             const std::vector<RDFLiteralPtr> &negativeLiterals)
+: AnswerBroadcaster(),
+  kg_(kg),
+  reasonerManager_(reasonerManager),
+  negativeLiterals_(negativeLiterals)
+{
+}
+
+void NegationStage::pushToBroadcast(const AnswerPtr &msg)
+{
+    if(isEOS(msg) || succeeds(msg)) {
+        AnswerBroadcaster::pushToBroadcast(msg);
+    }
+}
+
+bool NegationStage::succeeds(const AnswerPtr &answer)
+{
+    // here the idea is to issue individual queries for each negative literal.
+    // each query produces an AnswerBufferPtr object.
+    // the set of all results can then be checked for a certain property, e.g. that none or all
+    // of the queries produced a result.
+    std::vector<AnswerBufferPtr> results;
+
+    for(auto &lit : negativeLiterals_) {
+        // create an instance of the literal based on given substitution
+        auto instance = RDFLiteral::fromLiteral(
+                lit->applySubstitution(*answer->substitution()));
+
+        // for now evaluate positive variant of the literal.
+        // NOTE: for open-world semantics this cannot be done. open-world reasoner
+        //       would need to receive negative literal instead.
+        instance->setIsNegated(false);
+
+        // check if the EDB contains positive lit, if so negation cannot be true
+        results.push_back(kg_->submitQuery(
+                std::make_shared<GraphQuery>(instance, QUERY_FLAG_ALL_SOLUTIONS)));
+
+        // next check if positive lit is an IDB predicate, if so negation cannot be true.
+        // get list of reasoner that define the literal
+        // TODO: could be done faster through interface in manager
+        std::vector<std::shared_ptr<Reasoner>> l_reasoner;
+        for(auto &pair : reasonerManager_->reasonerPool()) {
+            auto &r = pair.second->reasoner();
+            if(r->canEvaluate(*lit)) {
+                results.push_back(r->submitQuery(instance, QUERY_FLAG_ALL_SOLUTIONS));
+            }
+        }
+    }
+
+    // go through results, ensure *all* sub-queries failed, only then the negation stage succeeds.
+    for(auto &result : results) {
+        auto resultQueue = result->createQueue();
+        auto firstResult = resultQueue->pop_front();
+        if(!isEOS(firstResult)) return false;
+    }
+
+    return true;
+}

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -8,62 +8,59 @@
 using namespace knowrob;
 
 NegationStage::NegationStage(const std::shared_ptr<KnowledgeGraph> &kg,
-                             const std::shared_ptr<ReasonerManager> &reasonerManager,
-                             const std::vector<RDFLiteralPtr> &negativeLiterals)
-: AnswerBroadcaster(),
-  kg_(kg),
-  reasonerManager_(reasonerManager),
-  negativeLiterals_(negativeLiterals)
-{
+							 const std::shared_ptr<ReasonerManager> &reasonerManager,
+							 const std::vector<RDFLiteralPtr> &negativeLiterals)
+		: AnswerBroadcaster(),
+		  kg_(kg),
+		  reasonerManager_(reasonerManager),
+		  negativeLiterals_(negativeLiterals) {
 }
 
-void NegationStage::pushToBroadcast(const AnswerPtr &msg)
-{
-    if(isEOS(msg) || succeeds(msg)) {
-        AnswerBroadcaster::pushToBroadcast(msg);
-    }
+void NegationStage::pushToBroadcast(const AnswerPtr &msg) {
+	if (isEOS(msg) || succeeds(msg)) {
+		AnswerBroadcaster::pushToBroadcast(msg);
+	}
 }
 
-bool NegationStage::succeeds(const AnswerPtr &answer)
-{
-    // here the idea is to issue individual queries for each negative literal.
-    // each query produces an AnswerBufferPtr object.
-    // the set of all results can then be checked for a certain property, e.g. that none or all
-    // of the queries produced a result.
-    std::vector<AnswerBufferPtr> results;
+bool NegationStage::succeeds(const AnswerPtr &answer) {
+	// here the idea is to issue individual queries for each negative literal.
+	// each query produces an AnswerBufferPtr object.
+	// the set of all results can then be checked for a certain property, e.g. that none or all
+	// of the queries produced a result.
+	std::vector<AnswerBufferPtr> results;
 
-    for(auto &lit : negativeLiterals_) {
-        // create an instance of the literal based on given substitution
-        auto instance = RDFLiteral::fromLiteral(
-                lit->applySubstitution(*answer->substitution()));
+	for (auto &lit: negativeLiterals_) {
+		// create an instance of the literal based on given substitution
+		auto instance = RDFLiteral::fromLiteral(
+				lit->applySubstitution(*answer->substitution()));
 
-        // for now evaluate positive variant of the literal.
-        // NOTE: for open-world semantics this cannot be done. open-world reasoner
-        //       would need to receive negative literal instead.
-        instance->setIsNegated(false);
+		// for now evaluate positive variant of the literal.
+		// NOTE: for open-world semantics this cannot be done. open-world reasoner
+		//       would need to receive negative literal instead.
+		instance->setIsNegated(false);
 
-        // check if the EDB contains positive lit, if so negation cannot be true
-        results.push_back(kg_->submitQuery(
-                std::make_shared<GraphQuery>(instance, QUERY_FLAG_ALL_SOLUTIONS)));
+		// check if the EDB contains positive lit, if so negation cannot be true
+		results.push_back(kg_->submitQuery(
+				std::make_shared<GraphQuery>(instance, QUERY_FLAG_ALL_SOLUTIONS)));
 
-        // next check if positive lit is an IDB predicate, if so negation cannot be true.
-        // get list of reasoner that define the literal
-        // TODO: could be done faster through interface in manager
-        std::vector<std::shared_ptr<Reasoner>> l_reasoner;
-        for(auto &pair : reasonerManager_->reasonerPool()) {
-            auto &r = pair.second->reasoner();
-            if(r->canEvaluate(*lit)) {
-                results.push_back(r->submitQuery(instance, QUERY_FLAG_ALL_SOLUTIONS));
-            }
-        }
-    }
+		// next check if positive lit is an IDB predicate, if so negation cannot be true.
+		// get list of reasoner that define the literal
+		// TODO: could be done faster through interface in manager
+		std::vector<std::shared_ptr<Reasoner>> l_reasoner;
+		for (auto &pair: reasonerManager_->reasonerPool()) {
+			auto &r = pair.second->reasoner();
+			if (r->canEvaluate(*lit)) {
+				results.push_back(r->submitQuery(instance, QUERY_FLAG_ALL_SOLUTIONS));
+			}
+		}
+	}
 
-    // go through results, ensure *all* sub-queries failed, only then the negation stage succeeds.
-    for(auto &result : results) {
-        auto resultQueue = result->createQueue();
-        auto firstResult = resultQueue->pop_front();
-        if(!isEOS(firstResult)) return false;
-    }
+	// go through results, ensure *all* sub-queries failed, only then the negation stage succeeds.
+	for (auto &result: results) {
+		auto resultQueue = result->createQueue();
+		auto firstResult = resultQueue->pop_front();
+		if (!isEOS(firstResult)) return false;
+	}
 
-    return true;
+	return true;
 }

--- a/src/queries/QueryParser.cpp
+++ b/src/queries/QueryParser.cpp
@@ -600,6 +600,15 @@ TEST_F(QueryParserTest, InvalidPredicates) {
     EXPECT_THROW(QueryParser::parsePredicate("p,q"), QueryError);
 }
 
+TEST_F(QueryParserTest, Negations) {
+    TEST_NO_THROW(testCompound(FormulaType::NEGATION,
+                               QueryParser::parse("~p"),
+                               1, {FormulaType::PREDICATE}))
+    TEST_NO_THROW(testCompound(FormulaType::NEGATION,
+                               QueryParser::parse("~(p&q)"),
+                               1, {FormulaType::CONJUNCTION}))
+}
+
 TEST_F(QueryParserTest, Conjunctions) {
     TEST_NO_THROW(testCompound(FormulaType::CONJUNCTION,
                                QueryParser::parse("p,q"),

--- a/src/semweb/RDFLiteral.cpp
+++ b/src/semweb/RDFLiteral.cpp
@@ -120,7 +120,7 @@ RDFLiteral::RDFLiteral(const RDFLiteral &other, const Substitution &sub)
 
 std::shared_ptr<RDFLiteral> RDFLiteral::fromLiteral(const LiteralPtr &literal)
 {
-    if(literal->arity()==2) {
+	if(literal->arity()==2) {
 		auto s = literal->predicate()->arguments()[0];
 		// TODO: a copy of the name is held by Vocabulary class
 		//  memory could be mapped into StringTerm but StringTerm does not support it yet.

--- a/src/semweb/RDFLiteral.cpp
+++ b/src/semweb/RDFLiteral.cpp
@@ -120,15 +120,24 @@ RDFLiteral::RDFLiteral(const RDFLiteral &other, const Substitution &sub)
 
 std::shared_ptr<RDFLiteral> RDFLiteral::fromLiteral(const LiteralPtr &literal)
 {
-    if(literal->arity()!=2) {
-        throw QueryError("RDF literal can only be constructed from 2-ary predicates but {} is not.", *literal);
-    }
-    auto s = literal->predicate()->arguments()[0];
-    // TODO: a copy of the name is held by Vocabulary class
-    //  memory could be mapped into StringTerm but StringTerm does not support it yet.
-    auto p = std::make_shared<StringTerm>(literal->functor());
-    auto o = literal->predicate()->arguments()[1];
-    return std::make_shared<RDFLiteral>(s,p,o,literal->isNegated(),literal->label());
+    if(literal->arity()==2) {
+		auto s = literal->predicate()->arguments()[0];
+		// TODO: a copy of the name is held by Vocabulary class
+		//  memory could be mapped into StringTerm but StringTerm does not support it yet.
+		auto p = std::make_shared<StringTerm>(literal->functor());
+		auto o = literal->predicate()->arguments()[1];
+		return std::make_shared<RDFLiteral>(s,p,o,literal->isNegated(),literal->label());
+	}
+	else if(literal->arity()==3 && literal->functor()=="triple") {
+		// handle triple/3 predicate here
+		auto s = literal->predicate()->arguments()[0];
+		auto p = literal->predicate()->arguments()[1];
+		auto o = literal->predicate()->arguments()[2];
+		return std::make_shared<RDFLiteral>(s,p,o,literal->isNegated(),literal->label());
+	}
+	else {
+		throw QueryError("RDF literal can only be constructed from 2-ary predicates but {} is not.", *literal);
+	}
 }
 
 std::shared_ptr<Term> RDFLiteral::getGraphTerm(const std::string_view &graphName)

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -163,8 +163,8 @@ TEST_F(KnowledgeBaseTest, negated_IDB) {
 }
 
 TEST_F(KnowledgeBaseTest, negatedComplex_EDB) {
-	const auto queryString = "(swrl_test:hasSibling(swrl_test:Fred,X) ; "\
-		"swrl_test:hasAncestor(swrl_test:Fred,X)) , ~swrl_test:hasSibling(X,Y)";
+	// Rex is an ancestor of Fred who does not have a sibling
+	const auto queryString = "swrl_test:hasAncestor(swrl_test:Fred,X) & ~swrl_test:hasSibling(X,Y)";
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
 	EXPECT_TRUE(containsAnswer(lookupAll(queryString), "X", QueryParser::parseConstant("swrl_test:Rex")));
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -152,9 +152,14 @@ TEST_F(KnowledgeBaseTest, complex_EDB) {
 }
 
 TEST_F(KnowledgeBaseTest, negated_EDB) {
-	const auto queryString = "~swrl_test:hasSibling(swrl_test:Lea,X)";
-	EXPECT_EQ(lookupAll(queryString).size(), 1);
-	EXPECT_TRUE(lookupAll(queryString)[0]->empty());
+	EXPECT_EQ(lookupAll("~swrl_test:hasSibling(swrl_test:Lea,X)").size(), 1);
+	EXPECT_TRUE(lookupAll("~swrl_test:hasSibling(swrl_test:Lea,X)")[0]->empty());
+	EXPECT_EQ(lookupAll("~swrl_test:hasSibling(swrl_test:Fred,X)").size(), 0);
+}
+
+TEST_F(KnowledgeBaseTest, negated_IDB) {
+	EXPECT_EQ(lookupAll("~p(swrl_test:Ernest, X)").size(), 0);
+	EXPECT_EQ(lookupAll("~p(swrl_test:Lea, X)").size(), 1);
 }
 
 TEST_F(KnowledgeBaseTest, negatedComplex_EDB) {


### PR DESCRIPTION
This pull request is concerned with support of negated statements in queries. For now, only *closed-world semantics* of negation is considered.

- so a query “~p” can be considered true if every reasoner agrees that “p” is false, and in addition the literal is not stored in EDB in positive form
- evaluation of negated literals should be deferred

note that at a later point open-world semantics should be supported too, and ultimatively it would be best to switch to three-valued predicates (true, false, don't know)