### PR TITLE
Query evaluation with QUERY_FLAG_ONE_SOLUTION set

### DIFF
--- a/include/knowrob/mongodb/Cursor.h
+++ b/include/knowrob/mongodb/Cursor.h
@@ -87,6 +87,7 @@ namespace knowrob::mongo {
         bson_t *opts_;
         std::string id_;
         bool isAggregateQuery_;
+		int64_t limit_;
     };
 }
 

--- a/include/knowrob/mongodb/MongoKnowledgeGraph.h
+++ b/include/knowrob/mongodb/MongoKnowledgeGraph.h
@@ -89,7 +89,7 @@ namespace knowrob {
          * @param tripleExpressions a vector of triple expressions
          * @return a cursor over matching triples
          */
-        mongo::AnswerCursorPtr lookup(const std::vector<RDFLiteralPtr> &tripleExpressions);
+        mongo::AnswerCursorPtr lookup(const std::vector<RDFLiteralPtr> &tripleExpressions, uint32_t limit=0);
 
         /**
          * @param graphName the name of a graph

--- a/src/mongodb/Cursor.cpp
+++ b/src/mongodb/Cursor.cpp
@@ -18,7 +18,8 @@ using namespace knowrob::mongo;
 Cursor::Cursor(const std::shared_ptr<Collection> &collection)
 : cursor_(nullptr),
   collection_(collection),
-  isAggregateQuery_(false)
+  isAggregateQuery_(false),
+  limit_(0)
 {
 	query_ = bson_new();
 	opts_ = bson_new();
@@ -40,7 +41,7 @@ Cursor::~Cursor()
 
 void Cursor::limit(unsigned int limit)
 {
-	BSON_APPEND_INT64(opts_, "limit", limit);
+	limit_ = limit;
 }
 
 void Cursor::ascending(const char *key)
@@ -76,6 +77,9 @@ bool Cursor::next(const bson_t **doc, bool ignore_empty)
 		else {
 			cursor_ = mongoc_collection_find_with_opts(
                     collection_->coll(), query_, opts_, nullptr /* read_prefs */ );
+		}
+		if(limit_ > 0) {
+			mongoc_cursor_set_limit(cursor_, limit_);
 		}
 		// make sure cursor has no error after creation
 		bson_error_t err1;

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -82,9 +82,9 @@ void KnowledgeBaseTest::SetUpTestSuite() {
 		"r2", std::make_shared<TestReasoner>("q", "x", "y"));
 }
 
-static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
+static std::vector<SubstitutionPtr> lookup(const std::string &queryString, QueryFlag qflag) {
 	auto answerStream = KnowledgeBaseTest::kb_->submitQuery(
-			QueryParser::parse(queryString), QUERY_FLAG_ALL_SOLUTIONS);
+			QueryParser::parse(queryString), qflag);
 	auto answerQueue = answerStream->createQueue();
 	std::vector<SubstitutionPtr> out;
 	while(true) {
@@ -93,6 +93,16 @@ static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
 		out.push_back(solution->substitution());
 	}
 	return out;
+}
+
+static std::vector<SubstitutionPtr> lookupAll(const std::string &queryString) {
+    return lookup(queryString, QUERY_FLAG_ALL_SOLUTIONS);
+
+}
+
+static std::vector<SubstitutionPtr> lookupOne(const std::string &queryString) {
+    return lookup(queryString, QUERY_FLAG_ONE_SOLUTION);
+
 }
 
 static bool containsAnswer(const std::vector<SubstitutionPtr> &answers, const std::string &key, const TermPtr &value) {
@@ -181,4 +191,9 @@ TEST_F(KnowledgeBaseTest, IDB_interaction) {
 	const auto queryString = "p(Ernest,X) , q(X,Y)";
 	EXPECT_EQ(lookupAll(queryString).size(), 1);
 	EXPECT_EQ(*lookupAll(queryString)[0]->get("Y"), StringTerm("y"));
+}
+
+TEST_F(KnowledgeBaseTest, ask_one) {
+    EXPECT_EQ(lookupOne("swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+    EXPECT_EQ(lookupOne("B swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -199,6 +199,6 @@ TEST_F(KnowledgeBaseTest, IDB_interaction) {
 }
 
 TEST_F(KnowledgeBaseTest, ask_one) {
-    EXPECT_EQ(lookupOne("swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
-    EXPECT_EQ(lookupOne("B swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+	EXPECT_EQ(lookupOne("swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
+	EXPECT_EQ(lookupOne("B swrl_test:hasSibling(swrl_test:Fred, X)").size(), 1);
 }


### PR DESCRIPTION
This pull request addresses the issue #378 

There were actually two problems:
- an exception was thrown indicating that the generated bson document has invalid syntax
- the query did not return in this case

The first problem seems related to a problem related to using `mongoc_cursor_set_limit`. For me seems like a bug in the mongo C driver. Anyways mongoc_cursor_set_limit can be avoided by using `$limit` aggregation stage.

The second problem was a bug on KnowRob's side that communication channels were not terminated by publishing an EOS message.