### PR TITLE
bugfix: uninitialized variable in PropertyTree

### DIFF
--- a/src/PropertyTree.cpp
+++ b/src/PropertyTree.cpp
@@ -16,7 +16,8 @@ PropertyTree::PropertyTree()
 		  delimiter_(".") {}
 
 PropertyTree::PropertyTree(const boost::property_tree::ptree *ptree)
-		: ptree_(ptree) {
+		: ptree_(ptree),
+		  delimiter_(".") {
 	static const std::string formatDefault = {};
 
 	// load all key-value pairs into settings map


### PR DESCRIPTION
Hi there!

While following along the getting started guide the `knowrob-terminal` would not fully start up. I managed to track down the issue to the `delimiter_` variable of `PropertyTree` not being initialized in all constructors. This let to an infinite loop in `PropertyTree::createKeyTerm`.

This PR fixes the issue above. Hope this is useful for you!