### PR TITLE
Fix prefix syntax error

### DIFF
--- a/src/queries/parsers/formula.cpp
+++ b/src/queries/parsers/formula.cpp
@@ -210,12 +210,12 @@ namespace knowrob::parsers::formula {
 	namespace qi = boost::spirit::qi;
 
 	PredicateRule &predicate_n() {
-		RETURN_PREDICATE_RULE((str::atom() >> '(' >> (term() % ',') >> ')')
+		RETURN_PREDICATE_RULE((str::atom_or_iri() >> '(' >> (term() % ',') >> ')')
 		                      [qi::_val = ptr_<Predicate>()(qi::_1, qi::_2)]);
 	}
 
 	PredicateRule &predicate_0() {
-		RETURN_PREDICATE_RULE(str::atom() [qi::_val = ptr_<Predicate>()(qi::_1, std::vector<TermPtr>())]);
+		RETURN_PREDICATE_RULE(str::atom_or_iri() [qi::_val = ptr_<Predicate>()(qi::_1, std::vector<TermPtr>())]);
 	}
 
 	PredicateRule &predicate() {

--- a/tests/QueryParserTest.cpp
+++ b/tests/QueryParserTest.cpp
@@ -169,7 +169,7 @@ TEST_F(QueryParserTest, PredicatesWithNS) {
 			QueryParser::parsePredicate("owl:p(X,Y)"),
 			"http://www.w3.org/2002/07/owl#p", 2, {TermType::VARIABLE, TermType::VARIABLE}));
 	TEST_NO_THROW(testPredicate(
-			QueryParser::parsePredicate("http://www.w3.org/2002/07/owl#p(X,Y)"),
+			QueryParser::parsePredicate("'http://www.w3.org/2002/07/owl#p'(X,Y)"),
 			"http://www.w3.org/2002/07/owl#p", 2, {TermType::VARIABLE, TermType::VARIABLE}));
 	TEST_NO_THROW(testPredicate(
 			QueryParser::parsePredicate("owl:p(owl:x, owl:y)"),

--- a/tests/QueryParserTest.cpp
+++ b/tests/QueryParserTest.cpp
@@ -164,6 +164,18 @@ TEST_F(QueryParserTest, Predicates) {
             "nullary", 0, {}))
 }
 
+TEST_F(QueryParserTest, PredicatesWithNS) {
+	TEST_NO_THROW(testPredicate(
+			QueryParser::parsePredicate("owl:p(X,Y)"),
+			"http://www.w3.org/2002/07/owl#p", 2, {TermType::VARIABLE, TermType::VARIABLE}));
+	TEST_NO_THROW(testPredicate(
+			QueryParser::parsePredicate("http://www.w3.org/2002/07/owl#p(X,Y)"),
+			"http://www.w3.org/2002/07/owl#p", 2, {TermType::VARIABLE, TermType::VARIABLE}));
+	TEST_NO_THROW(testPredicate(
+			QueryParser::parsePredicate("owl:p(owl:x, owl:y)"),
+			"http://www.w3.org/2002/07/owl#p", 2, {TermType::ATOMIC, TermType::ATOMIC}));
+}
+
 TEST_F(QueryParserTest, PredicateWithCompundArgument) {
     TEST_NO_THROW(testPredicate(
             QueryParser::parsePredicate("p(X,'<'(a))"),


### PR DESCRIPTION
This PR fixes a syntax error, when a prefix was used for predicates, e.g. swrl_test:hasAncestor(X,Y). Additionally, I added 3 test cases to cover this case.