### PR TITLE
Fixed unit test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,13 +50,14 @@ jobs:
         roscore &
         cd $GITHUB_WORKSPACE/ros_ws/src/knowrob
         source $GITHUB_WORKSPACE/ros_ws/devel_isolated/setup.bash
-        $GITHUB_WORKSPACE/ros_ws/build_isolated/knowrob/all_gtests --gtest_filter=* --gtest_output="xml:$GITHUB_WORKSPACE/gtest-knowrob.xml" --gtest_color=no
+        $GITHUB_WORKSPACE/ros_ws/devel_isolated/knowrob/lib/knowrob/all_gtests --gtest_filter=* --gtest_output="xml:$GITHUB_WORKSPACE/gtest-knowrob.xml" --gtest_color=no
     - name: Report test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         junit_files: "gtest-knowrob.xml"
         action_fail: true
+        action_fail_on_inconclusive: true
     #####
     - name: Run doxygen
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,13 @@ jobs:
         roscore &
         cd $GITHUB_WORKSPACE/ros_ws/src/knowrob
         source $GITHUB_WORKSPACE/ros_ws/devel_isolated/setup.bash
-        $GITHUB_WORKSPACE/ros_ws/build_isolated/knowrob/all_gtests --gtest_filter=* --gtest_output="xml:$GITHUB_WORKSPACE/gtest-knowrob.xml" --gtest_color=no || true
+        $GITHUB_WORKSPACE/ros_ws/build_isolated/knowrob/all_gtests --gtest_filter=* --gtest_output="xml:$GITHUB_WORKSPACE/gtest-knowrob.xml" --gtest_color=no
     - name: Report test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         junit_files: "gtest-knowrob.xml"
+        action_fail: true
     #####
     - name: Run doxygen
       if: ${{ github.event_name == 'push' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,16 @@ cmake_minimum_required(VERSION 3.5.0)
 set(CMAKE_CXX_FLAGS "-Wswitch -std=c++0x -pthread ${CMAKE_CXX_FLAGS} -Wno-undef")
 set(CMAKE_CXX_STANDARD 17)
 if (POLICY CMP0148)
-    cmake_policy(SET CMP0148 OLD)
+	cmake_policy(SET CMP0148 OLD)
 endif ()
 
 option(WITH_ROS1_INTERFACE "Build the interface for ROS1 systems" ON)
 
 project(knowrob
-        DESCRIPTION "A Knowledge Base System for Cognition-enabled Robots")
+		DESCRIPTION "A Knowledge Base System for Cognition-enabled Robots")
 
 IF (NOT WIN32)
-    INCLUDE(FindPkgConfig)
+	INCLUDE(FindPkgConfig)
 ENDIF ()
 
 set(SOMA_VERSION "current")
@@ -51,24 +51,24 @@ include_directories(include ${REDLAND_INCLUDE_DIRS})
 # copy them into the workspace such the we can load them
 # from a local source at runtime.
 install_ontology(
-        URL "http://www.ease-crc.org/ont/DUL.owl"
-        VERSION "3.34")
+		URL "http://www.ease-crc.org/ont/DUL.owl"
+		VERSION "3.34")
 install_ontology(
-        URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA.owl"
-        VERSION "${SOMA_VERSION}")
+		URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA.owl"
+		VERSION "${SOMA_VERSION}")
 install_ontology(
-        URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA-HOME.owl"
-        VERSION "${SOMA_VERSION}")
+		URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA-HOME.owl"
+		VERSION "${SOMA_VERSION}")
 # install all ontologies and default settings files
 install(DIRECTORY owl DESTINATION share/knowrob)
 install(DIRECTORY settings DESTINATION share/knowrob)
 
 set(CMAKE_CXX_FLAGS "-std=c++0x -pthread ${CMAKE_CXX_FLAGS}")
 include_directories(include
-        ${SWIPL_INCLUDE_DIRS}
-        ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
-        ${Python_INCLUDE_DIRS})
+		${SWIPL_INCLUDE_DIRS}
+		${EIGEN3_INCLUDE_DIR}
+		${Boost_INCLUDE_DIRS}
+		${Python_INCLUDE_DIRS})
 
 # define some constants for the compilation of source files that
 # are used to load project-relative files.
@@ -81,47 +81,47 @@ add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # NOTE: seems catkin_package must be called *before* any library is build.
 if (WITH_ROS1_INTERFACE)
-    find_package(catkin REQUIRED COMPONENTS
-        roscpp
-        rospy
-        std_msgs
-        message_generation
-        actionlib
-        actionlib_msgs
-    )
+	find_package(catkin REQUIRED COMPONENTS
+			roscpp
+			rospy
+			std_msgs
+			message_generation
+			actionlib
+			actionlib_msgs
+	)
 
-endif()
+endif ()
 if (WITH_ROS1_INTERFACE AND catkin_FOUND)
-    message(STATUS "Building with ROS1 support.")
+	message(STATUS "Building with ROS1 support.")
 
-    add_message_files(
-            DIRECTORY ros1/msg
-            FILES
-            KeyValuePair.msg
-            GraphQueryMessage.msg
-            GraphAnswerMessage.msg
-            EventToken.msg
-    )
+	add_message_files(
+			DIRECTORY ros1/msg
+			FILES
+			KeyValuePair.msg
+			GraphQueryMessage.msg
+			GraphAnswerMessage.msg
+			EventToken.msg
+	)
 
-    add_action_files(
-            DIRECTORY ros1/action
-            FILES
-            AskAll.action
-            AskOne.action
-            AskIncremental.action
-            AskIncrementalNextSolution.action
-            Tell.action
-    )
+	add_action_files(
+			DIRECTORY ros1/action
+			FILES
+			AskAll.action
+			AskOne.action
+			AskIncremental.action
+			AskIncrementalNextSolution.action
+			Tell.action
+	)
 
-    generate_messages(DEPENDENCIES
-            std_msgs
-            actionlib_msgs)
+	generate_messages(DEPENDENCIES
+			std_msgs
+			actionlib_msgs)
 
-    catkin_package(
-        CATKIN_DEPENDS roscpp roslib
-        CFG_EXTRAS ontologies.cmake
-    )
-endif()
+	catkin_package(
+			CATKIN_DEPENDS roscpp roslib
+			CFG_EXTRAS ontologies.cmake
+	)
+endif ()
 
 ##############
 #### MONGO DB
@@ -150,158 +150,158 @@ link_directories(${MONGOC_LIBRARY_DIRS})
 ##############
 
 add_library(knowrob SHARED
-        src/knowrob.cpp
-        src/ThreadPool.cpp
-        src/Logger.cpp
-        src/KnowledgeBase.cpp
-        src/ontologies/DataSource.cpp
-        src/URI.cpp
-        src/TimePoint.cpp
-        src/TimeInterval.cpp
-        src/terms/Term.cpp
-        src/terms/Variable.cpp
-        src/terms/ListTerm.cpp
-        src/terms/OptionList.cpp
-        src/terms/Bindings.cpp
-        src/terms/Unifier.cpp
-        src/formulas/Formula.cpp
-        src/formulas/CompoundFormula.cpp
-        src/formulas/Conjunction.cpp
-        src/formulas/Disjunction.cpp
-        src/formulas/Implication.cpp
-        src/formulas/Negation.cpp
-        src/formulas/Predicate.cpp
-        src/formulas/Bottom.cpp
-        src/formulas/Top.cpp
-        src/formulas/ModalFormula.cpp
-        src/formulas/ModalOperator.cpp
-        src/formulas/FirstOrderLiteral.cpp
-        src/queries/Answer.cpp
-        src/queries/TokenStream.cpp
-        src/queries/TokenQueue.cpp
-        src/queries/ConjunctiveBroadcaster.cpp
-        src/queries/TokenBroadcaster.cpp
-        src/formulas/DependencyGraph.cpp
-        src/queries/QueryParser.cpp
-        src/queries/QueryTree.cpp
-        src/queries/TokenBuffer.cpp
-        src/triples/GraphQuery.cpp
-        src/queries/Query.cpp
-        src/queries/RedundantAnswerFilter.cpp
-        src/queries/QueryStage.cpp
-        src/queries/QueryPipeline.cpp
-        src/queries/NegationStage.cpp
-        src/semweb/PrefixRegistry.cpp
-        src/semweb/PrefixProbe.cpp
-        src/semweb/xsd.cpp
-        src/semweb/Vocabulary.cpp
-        src/semweb/owl.cpp
-        src/semweb/rdfs.cpp
-        src/semweb/rdf.cpp
-        src/semweb/Property.cpp
-        src/semweb/Class.cpp
-        src/triples/FramedTriplePattern.cpp
-        src/semweb/ImportHierarchy.cpp
-        src/reasoner/Reasoner.cpp
-        src/reasoner/ReasonerManager.cpp
-        src/PropertyTree.cpp
-        src/integration/prolog/PrologEngine.cpp
-        src/integration/InterfaceUtils.cpp
-        src/reasoner/prolog/PrologReasoner.cpp
-        src/reasoner/prolog/PrologTests.cpp
-        src/integration/prolog/logging.cpp
-        src/integration/prolog/ext/algebra.cpp
-        src/reasoner/mongolog/MongologReasoner.cpp
-        src/reasoner/mongolog/mongo_kb.cpp
-        src/reasoner/mongolog/bson_pl.cpp
-        src/reasoner/swrl/SWRLReasoner.cpp
-        src/reasoner/esg/ESGReasoner.cpp
-        src/storage/QueryableStorage.cpp
-        src/storage/StorageManager.cpp
-        src/ontologies/DataSourceHandler.cpp
-        src/ontologies/OntologyFile.cpp
-        src/ontologies/OntologyParser.cpp
-        src/storage/Transaction.cpp
-        src/storage/mongo/MongoInterface.cpp
-        src/storage/mongo/Database.cpp
-        src/storage/mongo/Collection.cpp
-        src/storage/mongo/ChangeStream.cpp
-        src/storage/mongo/Cursor.cpp
-        src/storage/mongo/QueryWatch.cpp
-        src/storage/mongo/MongoKnowledgeGraph.cpp
-        src/storage/mongo/BulkOperation.cpp
-        src/storage/mongo/Pipeline.cpp
-        src/storage/mongo/TripleCursor.cpp
-        src/storage/mongo/BindingsCursor.cpp
-        src/storage/mongo/Connection.cpp
-        src/storage/mongo/bson-helper.cpp
-        src/queries/ModalStage.cpp
-        src/triples/Perspective.cpp
-        src/formulas/PredicateIndicator.cpp
-        src/queries/AnswerYes.cpp
-        src/queries/AnswerNo.cpp
-        src/queries/AnswerDontKnow.cpp
-        src/queries/DisjunctiveBroadcaster.cpp
-        src/queries/Token.cpp
-        src/triples/GraphSelector.cpp
-        src/queries/AnswerMerger.cpp
-        src/integration/python/utils.cpp
-        src/triples/FramedTriple.cpp
-        src/triples/TripleFormat.cpp
-        src/semweb/OntologyLanguage.cpp
-        src/reasoner/prolog/semweb.cpp
-        src/integration/prolog/PrologBackend.cpp
-        src/integration/prolog/PrologTerm.cpp
-        src/ontologies/SPARQLService.cpp
-        src/storage/redland/RaptorContainer.cpp
-        src/ontologies/GraphRenaming.cpp
-        src/ontologies/GraphRestructuring.cpp
-        src/storage/redland/RedlandModel.cpp
-        src/ontologies/GraphTransformation.cpp
-        src/terms/Atom.cpp
-        src/terms/Atomic.cpp
-        src/terms/Function.cpp
-        src/terms/XSDAtomic.cpp
-        src/terms/IRIAtom.cpp
-        src/terms/Blank.cpp
-        src/terms/RDFNode.cpp
-        src/semweb/Resource.cpp
-        src/terms/Numeric.cpp
-        src/terms/String.cpp
-        src/storage/Storage.cpp
-        src/queries/QueryContext.cpp
-        src/triples/SPARQLQuery.cpp
-        src/triples/TripleContainer.cpp
-        src/KnowRobError.cpp
-        src/integration/python/PythonError.cpp
-        src/storage/ReifiedTriple.cpp
-        src/storage/ReifiedQuery.cpp
-        src/storage/ReificationContainer.cpp
-        src/storage/UnReificationContainer.cpp
-        src/storage/StorageInterface.cpp
-        src/triples/GraphUnion.cpp
-        src/triples/GraphSequence.cpp
-        src/triples/GraphTerm.cpp
-        src/storage/mongo/MongoTriple.cpp
-        src/storage/mongo/MongoTriplePattern.cpp
-        src/storage/mongo/MongoTerm.cpp
-        src/storage/mongo/MongoTaxonomy.cpp
-        src/storage/SPARQLBackend.cpp
-        src/queries/parsers/strings.cpp
-        src/queries/parsers/terms.cpp
-        src/queries/parsers/formula.cpp
-        src/reasoner/GoalDrivenReasoner.cpp
-        src/reasoner/DataDrivenReasoner.cpp
-        src/reasoner/ReasonerEvent.cpp
-        src/ontologies/TransformedOntology.cpp)
+		src/knowrob.cpp
+		src/ThreadPool.cpp
+		src/Logger.cpp
+		src/KnowledgeBase.cpp
+		src/ontologies/DataSource.cpp
+		src/URI.cpp
+		src/TimePoint.cpp
+		src/TimeInterval.cpp
+		src/terms/Term.cpp
+		src/terms/Variable.cpp
+		src/terms/ListTerm.cpp
+		src/terms/OptionList.cpp
+		src/terms/Bindings.cpp
+		src/terms/Unifier.cpp
+		src/formulas/Formula.cpp
+		src/formulas/CompoundFormula.cpp
+		src/formulas/Conjunction.cpp
+		src/formulas/Disjunction.cpp
+		src/formulas/Implication.cpp
+		src/formulas/Negation.cpp
+		src/formulas/Predicate.cpp
+		src/formulas/Bottom.cpp
+		src/formulas/Top.cpp
+		src/formulas/ModalFormula.cpp
+		src/formulas/ModalOperator.cpp
+		src/formulas/FirstOrderLiteral.cpp
+		src/queries/Answer.cpp
+		src/queries/TokenStream.cpp
+		src/queries/TokenQueue.cpp
+		src/queries/ConjunctiveBroadcaster.cpp
+		src/queries/TokenBroadcaster.cpp
+		src/formulas/DependencyGraph.cpp
+		src/queries/QueryParser.cpp
+		src/queries/QueryTree.cpp
+		src/queries/TokenBuffer.cpp
+		src/triples/GraphQuery.cpp
+		src/queries/Query.cpp
+		src/queries/RedundantAnswerFilter.cpp
+		src/queries/QueryStage.cpp
+		src/queries/QueryPipeline.cpp
+		src/queries/NegationStage.cpp
+		src/semweb/PrefixRegistry.cpp
+		src/semweb/PrefixProbe.cpp
+		src/semweb/xsd.cpp
+		src/semweb/Vocabulary.cpp
+		src/semweb/owl.cpp
+		src/semweb/rdfs.cpp
+		src/semweb/rdf.cpp
+		src/semweb/Property.cpp
+		src/semweb/Class.cpp
+		src/triples/FramedTriplePattern.cpp
+		src/semweb/ImportHierarchy.cpp
+		src/reasoner/Reasoner.cpp
+		src/reasoner/ReasonerManager.cpp
+		src/PropertyTree.cpp
+		src/integration/prolog/PrologEngine.cpp
+		src/integration/InterfaceUtils.cpp
+		src/reasoner/prolog/PrologReasoner.cpp
+		src/reasoner/prolog/PrologTests.cpp
+		src/integration/prolog/logging.cpp
+		src/integration/prolog/ext/algebra.cpp
+		src/reasoner/mongolog/MongologReasoner.cpp
+		src/reasoner/mongolog/mongo_kb.cpp
+		src/reasoner/mongolog/bson_pl.cpp
+		src/reasoner/swrl/SWRLReasoner.cpp
+		src/reasoner/esg/ESGReasoner.cpp
+		src/storage/QueryableStorage.cpp
+		src/storage/StorageManager.cpp
+		src/ontologies/DataSourceHandler.cpp
+		src/ontologies/OntologyFile.cpp
+		src/ontologies/OntologyParser.cpp
+		src/storage/Transaction.cpp
+		src/storage/mongo/MongoInterface.cpp
+		src/storage/mongo/Database.cpp
+		src/storage/mongo/Collection.cpp
+		src/storage/mongo/ChangeStream.cpp
+		src/storage/mongo/Cursor.cpp
+		src/storage/mongo/QueryWatch.cpp
+		src/storage/mongo/MongoKnowledgeGraph.cpp
+		src/storage/mongo/BulkOperation.cpp
+		src/storage/mongo/Pipeline.cpp
+		src/storage/mongo/TripleCursor.cpp
+		src/storage/mongo/BindingsCursor.cpp
+		src/storage/mongo/Connection.cpp
+		src/storage/mongo/bson-helper.cpp
+		src/queries/ModalStage.cpp
+		src/triples/Perspective.cpp
+		src/formulas/PredicateIndicator.cpp
+		src/queries/AnswerYes.cpp
+		src/queries/AnswerNo.cpp
+		src/queries/AnswerDontKnow.cpp
+		src/queries/DisjunctiveBroadcaster.cpp
+		src/queries/Token.cpp
+		src/triples/GraphSelector.cpp
+		src/queries/AnswerMerger.cpp
+		src/integration/python/utils.cpp
+		src/triples/FramedTriple.cpp
+		src/triples/TripleFormat.cpp
+		src/semweb/OntologyLanguage.cpp
+		src/reasoner/prolog/semweb.cpp
+		src/integration/prolog/PrologBackend.cpp
+		src/integration/prolog/PrologTerm.cpp
+		src/ontologies/SPARQLService.cpp
+		src/storage/redland/RaptorContainer.cpp
+		src/ontologies/GraphRenaming.cpp
+		src/ontologies/GraphRestructuring.cpp
+		src/storage/redland/RedlandModel.cpp
+		src/ontologies/GraphTransformation.cpp
+		src/terms/Atom.cpp
+		src/terms/Atomic.cpp
+		src/terms/Function.cpp
+		src/terms/XSDAtomic.cpp
+		src/terms/IRIAtom.cpp
+		src/terms/Blank.cpp
+		src/terms/RDFNode.cpp
+		src/semweb/Resource.cpp
+		src/terms/Numeric.cpp
+		src/terms/String.cpp
+		src/storage/Storage.cpp
+		src/queries/QueryContext.cpp
+		src/triples/SPARQLQuery.cpp
+		src/triples/TripleContainer.cpp
+		src/KnowRobError.cpp
+		src/integration/python/PythonError.cpp
+		src/storage/ReifiedTriple.cpp
+		src/storage/ReifiedQuery.cpp
+		src/storage/ReificationContainer.cpp
+		src/storage/UnReificationContainer.cpp
+		src/storage/StorageInterface.cpp
+		src/triples/GraphUnion.cpp
+		src/triples/GraphSequence.cpp
+		src/triples/GraphTerm.cpp
+		src/storage/mongo/MongoTriple.cpp
+		src/storage/mongo/MongoTriplePattern.cpp
+		src/storage/mongo/MongoTerm.cpp
+		src/storage/mongo/MongoTaxonomy.cpp
+		src/storage/SPARQLBackend.cpp
+		src/queries/parsers/strings.cpp
+		src/queries/parsers/terms.cpp
+		src/queries/parsers/formula.cpp
+		src/reasoner/GoalDrivenReasoner.cpp
+		src/reasoner/DataDrivenReasoner.cpp
+		src/reasoner/ReasonerEvent.cpp
+		src/ontologies/TransformedOntology.cpp)
 set(KNOWROB_LIBRARIES
-        ${SWIPL_LIBRARIES}
-        ${MONGOC_LIBRARIES}
-        ${RAPTOR_LIBRARIES}
-        ${REDLAND_LIBRARIES}
-        ${Python_LIBRARIES}
-        spdlog::spdlog
-        ${GTEST_LIBRARIES})
+		${SWIPL_LIBRARIES}
+		${MONGOC_LIBRARIES}
+		${RAPTOR_LIBRARIES}
+		${REDLAND_LIBRARIES}
+		${Python_LIBRARIES}
+		spdlog::spdlog
+		${GTEST_LIBRARIES})
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
 install(TARGETS knowrob PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
@@ -312,11 +312,11 @@ install(DIRECTORY src/ DESTINATION share/knowrob FILES_MATCHING PATTERN "*.py")
 
 add_executable(knowrob-terminal src/terminal.cpp)
 target_link_libraries(knowrob-terminal
-        ${KNOWROB_LIBRARIES}
-        Boost::program_options
-        Boost::serialization
-        ${Boost_Python_COMPONENT}
-        knowrob)
+		${KNOWROB_LIBRARIES}
+		Boost::program_options
+		Boost::serialization
+		${Boost_Python_COMPONENT}
+		knowrob)
 install(TARGETS knowrob-terminal RUNTIME DESTINATION bin)
 
 ##############
@@ -328,16 +328,16 @@ set(CMAKE_SHARED_MODULE_PREFIX "")
 
 add_library(knowrob_py MODULE src/integration/python/knowrob_module.cpp)
 target_include_directories(knowrob_py PRIVATE
-        ${SWIPL_INCLUDE_DIRS}
-        ${EIGEN3_INCLUDE_DIR}
-        ${Boost_INCLUDE_DIRS}
-        ${PYTHON_INCLUDE_DIRS})
+		${SWIPL_INCLUDE_DIRS}
+		${EIGEN3_INCLUDE_DIR}
+		${Boost_INCLUDE_DIRS}
+		${PYTHON_INCLUDE_DIRS})
 target_link_libraries(knowrob_py PRIVATE
-        ${KNOWROB_LIBRARIES}
-        Boost::program_options
-        Boost::serialization
-        ${Boost_Python_COMPONENT}
-        knowrob)
+		${KNOWROB_LIBRARIES}
+		Boost::program_options
+		Boost::serialization
+		${Boost_Python_COMPONENT}
+		knowrob)
 
 # Rename the library to knowrob.so such that it can be loaded by the
 # Python interpreter through the "import knowrob" statement.
@@ -345,26 +345,45 @@ target_link_libraries(knowrob_py PRIVATE
 #       the PYTHONPATH needs to be set to include the build directory.
 # If catkin is used (e.g. in context of ROS) the library is in the devel space instead of build
 if (WITH_ROS1_INTERFACE AND catkin_FOUND AND CATKIN_DEVEL_PREFIX)
-    add_custom_command(TARGET knowrob_py POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
-        ${CMAKE_BINARY_DIR}/knowrob.so
-        COMMAND_EXPAND_LISTS)
-    add_custom_command(TARGET knowrob_py POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
-        ${CATKIN_DEVEL_PREFIX}/lib/python3/dist-packages/knowrob/kb.so
-        COMMAND_EXPAND_LISTS)
-else()
-    add_custom_command(TARGET knowrob_py POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_BINARY_DIR}/knowrob_py.so
-        ${CMAKE_BINARY_DIR}/knowrob.so
-        COMMAND_EXPAND_LISTS)
-endif()
+	# we build knowrob py a second time with a different modulename in python boost
+	# so that you can import it via knowrob.kb in ros1
+	add_library(kb MODULE src/integration/python/knowrob_module.cpp)
+	target_include_directories(kb PRIVATE
+			${SWIPL_INCLUDE_DIRS}
+			${EIGEN3_INCLUDE_DIR}
+			${Boost_INCLUDE_DIRS}
+			${PYTHON_INCLUDE_DIRS})
+	target_link_libraries(kb PRIVATE
+			${KNOWROB_LIBRARIES}
+			Boost::program_options
+			Boost::serialization
+			${Boost_Python_COMPONENT}
+			knowrob)
+	# Set the MODULENAME macro to "kb"
+	target_compile_definitions(kb PRIVATE
+			MODULENAME=kb)
+
+	# copy knowrob.py to the binary dir as knowrob.so
+	add_custom_command(TARGET knowrob_py POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+			${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
+			${CMAKE_BINARY_DIR}/kb.so
+			COMMAND_EXPAND_LISTS)
+	add_custom_command(TARGET kb POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+			${CATKIN_DEVEL_PREFIX}/lib/kb.so
+			${CATKIN_DEVEL_PREFIX}/lib/python3/dist-packages/knowrob/kb.so
+			COMMAND_EXPAND_LISTS)
+else ()
+	add_custom_command(TARGET knowrob_py POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+			${CMAKE_BINARY_DIR}/knowrob_py.so
+			${CMAKE_BINARY_DIR}/knowrob.so
+			COMMAND_EXPAND_LISTS)
+endif ()
 # install the Python module into the site-packages directory
 install(FILES ${CMAKE_BINARY_DIR}/knowrob.so
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
+		DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
 
 ##############
 ########## Doxygen
@@ -372,22 +391,22 @@ install(FILES ${CMAKE_BINARY_DIR}/knowrob.so
 
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
-    set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxyfile.in)
-    set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doxyfile)
-    configure_file(${doxyfile_in} ${doxyfile} @ONLY)
+	set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxyfile.in)
+	set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doxyfile)
+	configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 
-    if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css")
-        message(STATUS "Downloading \"doxygen-awesome.css\" into directory \"${CMAKE_CURRENT_BINARY_DIR}\".")
-        file(DOWNLOAD
-                https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.3.2/doxygen-awesome.css
-                ${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css)
-    endif ()
+	if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css")
+		message(STATUS "Downloading \"doxygen-awesome.css\" into directory \"${CMAKE_CURRENT_BINARY_DIR}\".")
+		file(DOWNLOAD
+				https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.3.2/doxygen-awesome.css
+				${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css)
+	endif ()
 
-    add_custom_target(doc
-            COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMENT "Generating API documentation with Doxygen"
-            VERBATIM)
+	add_custom_target(doc
+			COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+			COMMENT "Generating API documentation with Doxygen"
+			VERBATIM)
 endif ()
 
 ##############
@@ -396,35 +415,35 @@ endif ()
 
 if (WITH_ROS1_INTERFACE AND catkin_FOUND AND CATKIN_DEVEL_PREFIX)
 
-    include_directories(${catkin_INCLUDE_DIRS})
+	include_directories(${catkin_INCLUDE_DIRS})
 
-    add_definitions(-DKNOWROB_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+	add_definitions(-DKNOWROB_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
 
-    # catkin_python_setup()
+	# catkin_python_setup()
 
-    include_directories(
-      ${catkin_INCLUDE_DIRS}
-    )
+	include_directories(
+			${catkin_INCLUDE_DIRS}
+	)
 
-    ## ROS Interface ###
-    add_executable(knowrob-ros
-            src/integration/ros1/ROSInterface.cpp
-    )
-    add_dependencies(knowrob-ros
-            ${catkin_EXPORTED_TARGETS})
-    target_link_libraries(knowrob-ros
-            Boost::program_options
-            ${KNOWROB_LIBRARIES}
-            knowrob
-            ${catkin_LIBRARIES}
-            ${Boost_INCLUDE_DIRS}
-            ${PYTHON_INCLUDE_DIRS}
-            ${Boost_Python_COMPONENT})
-    install(TARGETS knowrob-ros RUNTIME DESTINATION bin)
+	## ROS Interface ###
+	add_executable(knowrob-ros
+			src/integration/ros1/ROSInterface.cpp
+	)
+	add_dependencies(knowrob-ros
+			${catkin_EXPORTED_TARGETS})
+	target_link_libraries(knowrob-ros
+			Boost::program_options
+			${KNOWROB_LIBRARIES}
+			knowrob
+			${catkin_LIBRARIES}
+			${Boost_INCLUDE_DIRS}
+			${PYTHON_INCLUDE_DIRS}
+			${Boost_Python_COMPONENT})
+	install(TARGETS knowrob-ros RUNTIME DESTINATION bin)
 
 
 else ()
-    message(STATUS "Building without ROS1 support.")
+	message(STATUS "Building without ROS1 support.")
 endif ()
 
 ##############
@@ -436,21 +455,21 @@ endif ()
 # where gtest won't find them without using the "--no-as-needed"
 # flag for the linker.
 add_executable(all_gtests
-        tests/gtests.cpp
-        tests/QueryParserTest.cpp
-        tests/KnowledgeBaseTest.cpp
-        tests/StorageTest.cpp
-        tests/py/test-module.cpp
-        tests/TokenBroadcasterTest.cpp
-        tests/QueryTreeTest.cpp
-        tests/DependencyGraphTest.cpp
-        tests/DataSourceTest.cpp
-        tests/ConjunctiveBroadcasterTest.cpp
-        tests/UnifierTest.cpp)
+		tests/gtests.cpp
+		tests/QueryParserTest.cpp
+		tests/KnowledgeBaseTest.cpp
+		tests/StorageTest.cpp
+		tests/py/test-module.cpp
+		tests/TokenBroadcasterTest.cpp
+		tests/QueryTreeTest.cpp
+		tests/DependencyGraphTest.cpp
+		tests/DataSourceTest.cpp
+		tests/ConjunctiveBroadcasterTest.cpp
+		tests/UnifierTest.cpp)
 add_dependencies(all_gtests knowrob_py)
 target_link_libraries(all_gtests
-        -Wl,--whole-archive,--no-as-needed
-        knowrob
-        -Wl,--no-whole-archive
-        ${Boost_Python_COMPONENT}
-        ${GTEST_MAIN_LIBRARIES})
+		-Wl,--whole-archive,--no-as-needed
+		knowrob
+		-Wl,--no-whole-archive
+		${Boost_Python_COMPONENT}
+		${GTEST_MAIN_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,16 @@ cmake_minimum_required(VERSION 3.5.0)
 set(CMAKE_CXX_FLAGS "-Wswitch -std=c++0x -pthread ${CMAKE_CXX_FLAGS} -Wno-undef")
 set(CMAKE_CXX_STANDARD 17)
 if (POLICY CMP0148)
-	cmake_policy(SET CMP0148 OLD)
+    cmake_policy(SET CMP0148 OLD)
 endif ()
 
 option(WITH_ROS1_INTERFACE "Build the interface for ROS1 systems" ON)
 
 project(knowrob
-		DESCRIPTION "A Knowledge Base System for Cognition-enabled Robots")
+        DESCRIPTION "A Knowledge Base System for Cognition-enabled Robots")
 
 IF (NOT WIN32)
-	INCLUDE(FindPkgConfig)
+    INCLUDE(FindPkgConfig)
 ENDIF ()
 
 set(SOMA_VERSION "current")
@@ -51,24 +51,24 @@ include_directories(include ${REDLAND_INCLUDE_DIRS})
 # copy them into the workspace such the we can load them
 # from a local source at runtime.
 install_ontology(
-		URL "http://www.ease-crc.org/ont/DUL.owl"
-		VERSION "3.34")
+        URL "http://www.ease-crc.org/ont/DUL.owl"
+        VERSION "3.34")
 install_ontology(
-		URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA.owl"
-		VERSION "${SOMA_VERSION}")
+        URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA.owl"
+        VERSION "${SOMA_VERSION}")
 install_ontology(
-		URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA-HOME.owl"
-		VERSION "${SOMA_VERSION}")
+        URL "https://ease-crc.github.io/soma/owl/${SOMA_VERSION}/SOMA-HOME.owl"
+        VERSION "${SOMA_VERSION}")
 # install all ontologies and default settings files
 install(DIRECTORY owl DESTINATION share/knowrob)
 install(DIRECTORY settings DESTINATION share/knowrob)
 
 set(CMAKE_CXX_FLAGS "-std=c++0x -pthread ${CMAKE_CXX_FLAGS}")
 include_directories(include
-		${SWIPL_INCLUDE_DIRS}
-		${EIGEN3_INCLUDE_DIR}
-		${Boost_INCLUDE_DIRS}
-		${Python_INCLUDE_DIRS})
+        ${SWIPL_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
+        ${Boost_INCLUDE_DIRS}
+        ${Python_INCLUDE_DIRS})
 
 # define some constants for the compilation of source files that
 # are used to load project-relative files.
@@ -81,47 +81,47 @@ add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # NOTE: seems catkin_package must be called *before* any library is build.
 if (WITH_ROS1_INTERFACE)
-	find_package(catkin REQUIRED COMPONENTS
-			roscpp
-			rospy
-			std_msgs
-			message_generation
-			actionlib
-			actionlib_msgs
-	)
+    find_package(catkin REQUIRED COMPONENTS
+        roscpp
+        rospy
+        std_msgs
+        message_generation
+        actionlib
+        actionlib_msgs
+    )
 
-endif ()
+endif()
 if (WITH_ROS1_INTERFACE AND catkin_FOUND)
-	message(STATUS "Building with ROS1 support.")
+    message(STATUS "Building with ROS1 support.")
 
-	add_message_files(
-			DIRECTORY ros1/msg
-			FILES
-			KeyValuePair.msg
-			GraphQueryMessage.msg
-			GraphAnswerMessage.msg
-			EventToken.msg
-	)
+    add_message_files(
+            DIRECTORY ros1/msg
+            FILES
+            KeyValuePair.msg
+            GraphQueryMessage.msg
+            GraphAnswerMessage.msg
+            EventToken.msg
+    )
 
-	add_action_files(
-			DIRECTORY ros1/action
-			FILES
-			AskAll.action
-			AskOne.action
-			AskIncremental.action
-			AskIncrementalNextSolution.action
-			Tell.action
-	)
+    add_action_files(
+            DIRECTORY ros1/action
+            FILES
+            AskAll.action
+            AskOne.action
+            AskIncremental.action
+            AskIncrementalNextSolution.action
+            Tell.action
+    )
 
-	generate_messages(DEPENDENCIES
-			std_msgs
-			actionlib_msgs)
+    generate_messages(DEPENDENCIES
+            std_msgs
+            actionlib_msgs)
 
-	catkin_package(
-			CATKIN_DEPENDS roscpp roslib
-			CFG_EXTRAS ontologies.cmake
-	)
-endif ()
+    catkin_package(
+        CATKIN_DEPENDS roscpp roslib
+        CFG_EXTRAS ontologies.cmake
+    )
+endif()
 
 ##############
 #### MONGO DB
@@ -133,175 +133,175 @@ include_directories(${MONGOC_INCLUDE_DIRS})
 link_directories(${MONGOC_LIBRARY_DIRS})
 
 #add_library(mongo_kb SHARED
-#		src/mongodb/mongo_kb.cpp
-#		src/mongodb/bson_pl.cpp
-#		src/mongodb/MongoException.cpp
-#		src/mongodb/MongoInterface.cpp
-#		src/mongodb/MongoDatabase.cpp
-#		src/mongodb/MongoCollection.cpp
-#		src/mongodb/MongoCursor.cpp
-#		src/mongodb/MongoWatch.cpp)
+#       src/mongodb/mongo_kb.cpp
+#       src/mongodb/bson_pl.cpp
+#       src/mongodb/MongoException.cpp
+#       src/mongodb/MongoInterface.cpp
+#       src/mongodb/MongoDatabase.cpp
+#       src/mongodb/MongoCollection.cpp
+#       src/mongodb/MongoCursor.cpp
+#       src/mongodb/MongoWatch.cpp)
 #target_link_libraries(mongo_kb
-#		${SWIPL_LIBRARIES}
-#		${MONGOC_LIBRARIES})
+#       ${SWIPL_LIBRARIES}
+#       ${MONGOC_LIBRARIES})
 
 ##############
 #### QUERY ANSWERING
 ##############
 
 add_library(knowrob SHARED
-		src/knowrob.cpp
-		src/ThreadPool.cpp
-		src/Logger.cpp
-		src/KnowledgeBase.cpp
-		src/ontologies/DataSource.cpp
-		src/URI.cpp
-		src/TimePoint.cpp
-		src/TimeInterval.cpp
-		src/terms/Term.cpp
-		src/terms/Variable.cpp
-		src/terms/ListTerm.cpp
-		src/terms/OptionList.cpp
-		src/terms/Bindings.cpp
-		src/terms/Unifier.cpp
-		src/formulas/Formula.cpp
-		src/formulas/CompoundFormula.cpp
-		src/formulas/Conjunction.cpp
-		src/formulas/Disjunction.cpp
-		src/formulas/Implication.cpp
-		src/formulas/Negation.cpp
-		src/formulas/Predicate.cpp
-		src/formulas/Bottom.cpp
-		src/formulas/Top.cpp
-		src/formulas/ModalFormula.cpp
-		src/formulas/ModalOperator.cpp
-		src/formulas/FirstOrderLiteral.cpp
-		src/queries/Answer.cpp
-		src/queries/TokenStream.cpp
-		src/queries/TokenQueue.cpp
-		src/queries/ConjunctiveBroadcaster.cpp
-		src/queries/TokenBroadcaster.cpp
-		src/formulas/DependencyGraph.cpp
-		src/queries/QueryParser.cpp
-		src/queries/QueryTree.cpp
-		src/queries/TokenBuffer.cpp
-		src/triples/GraphQuery.cpp
-		src/queries/Query.cpp
-		src/queries/RedundantAnswerFilter.cpp
-		src/queries/QueryStage.cpp
-		src/queries/QueryPipeline.cpp
-		src/queries/NegationStage.cpp
-		src/semweb/PrefixRegistry.cpp
-		src/semweb/PrefixProbe.cpp
-		src/semweb/xsd.cpp
-		src/semweb/Vocabulary.cpp
-		src/semweb/owl.cpp
-		src/semweb/rdfs.cpp
-		src/semweb/rdf.cpp
-		src/semweb/Property.cpp
-		src/semweb/Class.cpp
-		src/triples/FramedTriplePattern.cpp
-		src/semweb/ImportHierarchy.cpp
-		src/reasoner/Reasoner.cpp
-		src/reasoner/ReasonerManager.cpp
-		src/PropertyTree.cpp
-		src/integration/prolog/PrologEngine.cpp
-		src/integration/InterfaceUtils.cpp
-		src/reasoner/prolog/PrologReasoner.cpp
-		src/reasoner/prolog/PrologTests.cpp
-		src/integration/prolog/logging.cpp
-		src/integration/prolog/ext/algebra.cpp
-		src/reasoner/mongolog/MongologReasoner.cpp
-		src/reasoner/mongolog/mongo_kb.cpp
-		src/reasoner/mongolog/bson_pl.cpp
-		src/reasoner/swrl/SWRLReasoner.cpp
-		src/reasoner/esg/ESGReasoner.cpp
-		src/storage/QueryableStorage.cpp
-		src/storage/StorageManager.cpp
-		src/ontologies/DataSourceHandler.cpp
-		src/ontologies/OntologyFile.cpp
-		src/ontologies/OntologyParser.cpp
-		src/storage/Transaction.cpp
-		src/storage/mongo/MongoInterface.cpp
-		src/storage/mongo/Database.cpp
-		src/storage/mongo/Collection.cpp
-		src/storage/mongo/ChangeStream.cpp
-		src/storage/mongo/Cursor.cpp
-		src/storage/mongo/QueryWatch.cpp
-		src/storage/mongo/MongoKnowledgeGraph.cpp
-		src/storage/mongo/BulkOperation.cpp
-		src/storage/mongo/Pipeline.cpp
-		src/storage/mongo/TripleCursor.cpp
-		src/storage/mongo/BindingsCursor.cpp
-		src/storage/mongo/Connection.cpp
-		src/storage/mongo/bson-helper.cpp
-		src/queries/ModalStage.cpp
-		src/triples/Perspective.cpp
-		src/formulas/PredicateIndicator.cpp
-		src/queries/AnswerYes.cpp
-		src/queries/AnswerNo.cpp
-		src/queries/AnswerDontKnow.cpp
-		src/queries/DisjunctiveBroadcaster.cpp
-		src/queries/Token.cpp
-		src/triples/GraphSelector.cpp
-		src/queries/AnswerMerger.cpp
-		src/integration/python/utils.cpp
-		src/triples/FramedTriple.cpp
-		src/triples/TripleFormat.cpp
-		src/semweb/OntologyLanguage.cpp
-		src/reasoner/prolog/semweb.cpp
-		src/integration/prolog/PrologBackend.cpp
-		src/integration/prolog/PrologTerm.cpp
-		src/ontologies/SPARQLService.cpp
-		src/storage/redland/RaptorContainer.cpp
-		src/ontologies/GraphRenaming.cpp
-		src/ontologies/GraphRestructuring.cpp
-		src/storage/redland/RedlandModel.cpp
-		src/ontologies/GraphTransformation.cpp
-		src/terms/Atom.cpp
-		src/terms/Atomic.cpp
-		src/terms/Function.cpp
-		src/terms/XSDAtomic.cpp
-		src/terms/IRIAtom.cpp
-		src/terms/Blank.cpp
-		src/terms/RDFNode.cpp
-		src/semweb/Resource.cpp
-		src/terms/Numeric.cpp
-		src/terms/String.cpp
-		src/storage/Storage.cpp
-		src/queries/QueryContext.cpp
-		src/triples/SPARQLQuery.cpp
-		src/triples/TripleContainer.cpp
-		src/KnowRobError.cpp
-		src/integration/python/PythonError.cpp
-		src/storage/ReifiedTriple.cpp
-		src/storage/ReifiedQuery.cpp
-		src/storage/ReificationContainer.cpp
-		src/storage/UnReificationContainer.cpp
-		src/storage/StorageInterface.cpp
-		src/triples/GraphUnion.cpp
-		src/triples/GraphSequence.cpp
-		src/triples/GraphTerm.cpp
-		src/storage/mongo/MongoTriple.cpp
-		src/storage/mongo/MongoTriplePattern.cpp
-		src/storage/mongo/MongoTerm.cpp
-		src/storage/mongo/MongoTaxonomy.cpp
-		src/storage/SPARQLBackend.cpp
-		src/queries/parsers/strings.cpp
-		src/queries/parsers/terms.cpp
-		src/queries/parsers/formula.cpp
-		src/reasoner/GoalDrivenReasoner.cpp
-		src/reasoner/DataDrivenReasoner.cpp
-		src/reasoner/ReasonerEvent.cpp
-		src/ontologies/TransformedOntology.cpp)
+        src/knowrob.cpp
+        src/ThreadPool.cpp
+        src/Logger.cpp
+        src/KnowledgeBase.cpp
+        src/ontologies/DataSource.cpp
+        src/URI.cpp
+        src/TimePoint.cpp
+        src/TimeInterval.cpp
+        src/terms/Term.cpp
+        src/terms/Variable.cpp
+        src/terms/ListTerm.cpp
+        src/terms/OptionList.cpp
+        src/terms/Bindings.cpp
+        src/terms/Unifier.cpp
+        src/formulas/Formula.cpp
+        src/formulas/CompoundFormula.cpp
+        src/formulas/Conjunction.cpp
+        src/formulas/Disjunction.cpp
+        src/formulas/Implication.cpp
+        src/formulas/Negation.cpp
+        src/formulas/Predicate.cpp
+        src/formulas/Bottom.cpp
+        src/formulas/Top.cpp
+        src/formulas/ModalFormula.cpp
+        src/formulas/ModalOperator.cpp
+        src/formulas/FirstOrderLiteral.cpp
+        src/queries/Answer.cpp
+        src/queries/TokenStream.cpp
+        src/queries/TokenQueue.cpp
+        src/queries/ConjunctiveBroadcaster.cpp
+        src/queries/TokenBroadcaster.cpp
+        src/formulas/DependencyGraph.cpp
+        src/queries/QueryParser.cpp
+        src/queries/QueryTree.cpp
+        src/queries/TokenBuffer.cpp
+        src/triples/GraphQuery.cpp
+        src/queries/Query.cpp
+        src/queries/RedundantAnswerFilter.cpp
+        src/queries/QueryStage.cpp
+        src/queries/QueryPipeline.cpp
+        src/queries/NegationStage.cpp
+        src/semweb/PrefixRegistry.cpp
+        src/semweb/PrefixProbe.cpp
+        src/semweb/xsd.cpp
+        src/semweb/Vocabulary.cpp
+        src/semweb/owl.cpp
+        src/semweb/rdfs.cpp
+        src/semweb/rdf.cpp
+        src/semweb/Property.cpp
+        src/semweb/Class.cpp
+        src/triples/FramedTriplePattern.cpp
+        src/semweb/ImportHierarchy.cpp
+        src/reasoner/Reasoner.cpp
+        src/reasoner/ReasonerManager.cpp
+        src/PropertyTree.cpp
+        src/integration/prolog/PrologEngine.cpp
+        src/integration/InterfaceUtils.cpp
+        src/reasoner/prolog/PrologReasoner.cpp
+        src/reasoner/prolog/PrologTests.cpp
+        src/integration/prolog/logging.cpp
+        src/integration/prolog/ext/algebra.cpp
+        src/reasoner/mongolog/MongologReasoner.cpp
+        src/reasoner/mongolog/mongo_kb.cpp
+        src/reasoner/mongolog/bson_pl.cpp
+        src/reasoner/swrl/SWRLReasoner.cpp
+        src/reasoner/esg/ESGReasoner.cpp
+        src/storage/QueryableStorage.cpp
+        src/storage/StorageManager.cpp
+        src/ontologies/DataSourceHandler.cpp
+        src/ontologies/OntologyFile.cpp
+        src/ontologies/OntologyParser.cpp
+        src/storage/Transaction.cpp
+        src/storage/mongo/MongoInterface.cpp
+        src/storage/mongo/Database.cpp
+        src/storage/mongo/Collection.cpp
+        src/storage/mongo/ChangeStream.cpp
+        src/storage/mongo/Cursor.cpp
+        src/storage/mongo/QueryWatch.cpp
+        src/storage/mongo/MongoKnowledgeGraph.cpp
+        src/storage/mongo/BulkOperation.cpp
+        src/storage/mongo/Pipeline.cpp
+        src/storage/mongo/TripleCursor.cpp
+        src/storage/mongo/BindingsCursor.cpp
+        src/storage/mongo/Connection.cpp
+        src/storage/mongo/bson-helper.cpp
+        src/queries/ModalStage.cpp
+        src/triples/Perspective.cpp
+        src/formulas/PredicateIndicator.cpp
+        src/queries/AnswerYes.cpp
+        src/queries/AnswerNo.cpp
+        src/queries/AnswerDontKnow.cpp
+        src/queries/DisjunctiveBroadcaster.cpp
+        src/queries/Token.cpp
+        src/triples/GraphSelector.cpp
+        src/queries/AnswerMerger.cpp
+        src/integration/python/utils.cpp
+        src/triples/FramedTriple.cpp
+        src/triples/TripleFormat.cpp
+        src/semweb/OntologyLanguage.cpp
+        src/reasoner/prolog/semweb.cpp
+        src/integration/prolog/PrologBackend.cpp
+        src/integration/prolog/PrologTerm.cpp
+        src/ontologies/SPARQLService.cpp
+        src/storage/redland/RaptorContainer.cpp
+        src/ontologies/GraphRenaming.cpp
+        src/ontologies/GraphRestructuring.cpp
+        src/storage/redland/RedlandModel.cpp
+        src/ontologies/GraphTransformation.cpp
+        src/terms/Atom.cpp
+        src/terms/Atomic.cpp
+        src/terms/Function.cpp
+        src/terms/XSDAtomic.cpp
+        src/terms/IRIAtom.cpp
+        src/terms/Blank.cpp
+        src/terms/RDFNode.cpp
+        src/semweb/Resource.cpp
+        src/terms/Numeric.cpp
+        src/terms/String.cpp
+        src/storage/Storage.cpp
+        src/queries/QueryContext.cpp
+        src/triples/SPARQLQuery.cpp
+        src/triples/TripleContainer.cpp
+        src/KnowRobError.cpp
+        src/integration/python/PythonError.cpp
+        src/storage/ReifiedTriple.cpp
+        src/storage/ReifiedQuery.cpp
+        src/storage/ReificationContainer.cpp
+        src/storage/UnReificationContainer.cpp
+        src/storage/StorageInterface.cpp
+        src/triples/GraphUnion.cpp
+        src/triples/GraphSequence.cpp
+        src/triples/GraphTerm.cpp
+        src/storage/mongo/MongoTriple.cpp
+        src/storage/mongo/MongoTriplePattern.cpp
+        src/storage/mongo/MongoTerm.cpp
+        src/storage/mongo/MongoTaxonomy.cpp
+        src/storage/SPARQLBackend.cpp
+        src/queries/parsers/strings.cpp
+        src/queries/parsers/terms.cpp
+        src/queries/parsers/formula.cpp
+        src/reasoner/GoalDrivenReasoner.cpp
+        src/reasoner/DataDrivenReasoner.cpp
+        src/reasoner/ReasonerEvent.cpp
+        src/ontologies/TransformedOntology.cpp)
 set(KNOWROB_LIBRARIES
-		${SWIPL_LIBRARIES}
-		${MONGOC_LIBRARIES}
-		${RAPTOR_LIBRARIES}
-		${REDLAND_LIBRARIES}
-		${Python_LIBRARIES}
-		spdlog::spdlog
-		${GTEST_LIBRARIES})
+        ${SWIPL_LIBRARIES}
+        ${MONGOC_LIBRARIES}
+        ${RAPTOR_LIBRARIES}
+        ${REDLAND_LIBRARIES}
+        ${Python_LIBRARIES}
+        spdlog::spdlog
+        ${GTEST_LIBRARIES})
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
 install(TARGETS knowrob PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
@@ -312,11 +312,11 @@ install(DIRECTORY src/ DESTINATION share/knowrob FILES_MATCHING PATTERN "*.py")
 
 add_executable(knowrob-terminal src/terminal.cpp)
 target_link_libraries(knowrob-terminal
-		${KNOWROB_LIBRARIES}
-		Boost::program_options
-		Boost::serialization
-		${Boost_Python_COMPONENT}
-		knowrob)
+        ${KNOWROB_LIBRARIES}
+        Boost::program_options
+        Boost::serialization
+        ${Boost_Python_COMPONENT}
+        knowrob)
 install(TARGETS knowrob-terminal RUNTIME DESTINATION bin)
 
 ##############
@@ -328,16 +328,16 @@ set(CMAKE_SHARED_MODULE_PREFIX "")
 
 add_library(knowrob_py MODULE src/integration/python/knowrob_module.cpp)
 target_include_directories(knowrob_py PRIVATE
-		${SWIPL_INCLUDE_DIRS}
-		${EIGEN3_INCLUDE_DIR}
-		${Boost_INCLUDE_DIRS}
-		${PYTHON_INCLUDE_DIRS})
+        ${SWIPL_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
+        ${Boost_INCLUDE_DIRS}
+        ${PYTHON_INCLUDE_DIRS})
 target_link_libraries(knowrob_py PRIVATE
-		${KNOWROB_LIBRARIES}
-		Boost::program_options
-		Boost::serialization
-		${Boost_Python_COMPONENT}
-		knowrob)
+        ${KNOWROB_LIBRARIES}
+        Boost::program_options
+        Boost::serialization
+        ${Boost_Python_COMPONENT}
+        knowrob)
 
 # Rename the library to knowrob.so such that it can be loaded by the
 # Python interpreter through the "import knowrob" statement.
@@ -345,45 +345,45 @@ target_link_libraries(knowrob_py PRIVATE
 #       the PYTHONPATH needs to be set to include the build directory.
 # If catkin is used (e.g. in context of ROS) the library is in the devel space instead of build
 if (WITH_ROS1_INTERFACE AND catkin_FOUND AND CATKIN_DEVEL_PREFIX)
-	# we build knowrob py a second time with a different modulename in python boost
-	# so that you can import it via knowrob.kb in ros1
-	add_library(kb MODULE src/integration/python/knowrob_module.cpp)
-	target_include_directories(kb PRIVATE
-			${SWIPL_INCLUDE_DIRS}
-			${EIGEN3_INCLUDE_DIR}
-			${Boost_INCLUDE_DIRS}
-			${PYTHON_INCLUDE_DIRS})
-	target_link_libraries(kb PRIVATE
-			${KNOWROB_LIBRARIES}
-			Boost::program_options
-			Boost::serialization
-			${Boost_Python_COMPONENT}
-			knowrob)
-	# Set the MODULENAME macro to "kb"
-	target_compile_definitions(kb PRIVATE
-			MODULENAME=kb)
+    # we build knowrob py a second time with a different modulename in python boost
+    # so that you can import it via knowrob.kb in ros1
+    add_library(kb MODULE src/integration/python/knowrob_module.cpp)
+    target_include_directories(kb PRIVATE
+            ${SWIPL_INCLUDE_DIRS}
+            ${EIGEN3_INCLUDE_DIR}
+            ${Boost_INCLUDE_DIRS}
+            ${PYTHON_INCLUDE_DIRS})
+    target_link_libraries(kb PRIVATE
+            ${KNOWROB_LIBRARIES}
+            Boost::program_options
+            Boost::serialization
+            ${Boost_Python_COMPONENT}
+            knowrob)
+    # Set the MODULENAME macro to "kb"
+    target_compile_definitions(kb PRIVATE
+            MODULENAME=kb)
 
-	# copy knowrob.py to the binary dir as knowrob.so
-	add_custom_command(TARGET knowrob_py POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy
-			${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
-			${CMAKE_BINARY_DIR}/kb.so
-			COMMAND_EXPAND_LISTS)
-	add_custom_command(TARGET kb POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy
-			${CATKIN_DEVEL_PREFIX}/lib/kb.so
-			${CATKIN_DEVEL_PREFIX}/lib/python3/dist-packages/knowrob/kb.so
-			COMMAND_EXPAND_LISTS)
-else ()
-	add_custom_command(TARGET knowrob_py POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy
-			${CMAKE_BINARY_DIR}/knowrob_py.so
-			${CMAKE_BINARY_DIR}/knowrob.so
-			COMMAND_EXPAND_LISTS)
-endif ()
+    # copy knowrob.py to the binary dir as knowrob.so
+    add_custom_command(TARGET knowrob_py POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
+        ${CMAKE_BINARY_DIR}/knowrob.so
+        COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET kb POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CATKIN_DEVEL_PREFIX}/lib/kb.so
+        ${CATKIN_DEVEL_PREFIX}/lib/python3/dist-packages/knowrob/kb.so
+        COMMAND_EXPAND_LISTS)
+else()
+    add_custom_command(TARGET knowrob_py POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_BINARY_DIR}/knowrob_py.so
+        ${CMAKE_BINARY_DIR}/knowrob.so
+        COMMAND_EXPAND_LISTS)
+endif()
 # install the Python module into the site-packages directory
 install(FILES ${CMAKE_BINARY_DIR}/knowrob.so
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
 
 ##############
 ########## Doxygen
@@ -391,22 +391,22 @@ install(FILES ${CMAKE_BINARY_DIR}/knowrob.so
 
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
-	set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxyfile.in)
-	set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doxyfile)
-	configure_file(${doxyfile_in} ${doxyfile} @ONLY)
+    set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/doxyfile.in)
+    set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/doxyfile)
+    configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 
-	if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css")
-		message(STATUS "Downloading \"doxygen-awesome.css\" into directory \"${CMAKE_CURRENT_BINARY_DIR}\".")
-		file(DOWNLOAD
-				https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.3.2/doxygen-awesome.css
-				${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css)
-	endif ()
+    if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css")
+        message(STATUS "Downloading \"doxygen-awesome.css\" into directory \"${CMAKE_CURRENT_BINARY_DIR}\".")
+        file(DOWNLOAD
+                https://raw.githubusercontent.com/jothepro/doxygen-awesome-css/v2.3.2/doxygen-awesome.css
+                ${CMAKE_CURRENT_BINARY_DIR}/doxygen-awesome.css)
+    endif ()
 
-	add_custom_target(doc
-			COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			COMMENT "Generating API documentation with Doxygen"
-			VERBATIM)
+    add_custom_target(doc
+            COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Generating API documentation with Doxygen"
+            VERBATIM)
 endif ()
 
 ##############
@@ -415,35 +415,35 @@ endif ()
 
 if (WITH_ROS1_INTERFACE AND catkin_FOUND AND CATKIN_DEVEL_PREFIX)
 
-	include_directories(${catkin_INCLUDE_DIRS})
+    include_directories(${catkin_INCLUDE_DIRS})
 
-	add_definitions(-DKNOWROB_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+    add_definitions(-DKNOWROB_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
 
-	# catkin_python_setup()
+    # catkin_python_setup()
 
-	include_directories(
-			${catkin_INCLUDE_DIRS}
-	)
+    include_directories(
+            ${catkin_INCLUDE_DIRS}
+    )
 
-	## ROS Interface ###
-	add_executable(knowrob-ros
-			src/integration/ros1/ROSInterface.cpp
-	)
-	add_dependencies(knowrob-ros
-			${catkin_EXPORTED_TARGETS})
-	target_link_libraries(knowrob-ros
-			Boost::program_options
-			${KNOWROB_LIBRARIES}
-			knowrob
-			${catkin_LIBRARIES}
-			${Boost_INCLUDE_DIRS}
-			${PYTHON_INCLUDE_DIRS}
-			${Boost_Python_COMPONENT})
-	install(TARGETS knowrob-ros RUNTIME DESTINATION bin)
+    ## ROS Interface ###
+    add_executable(knowrob-ros
+            src/integration/ros1/ROSInterface.cpp
+    )
+    add_dependencies(knowrob-ros
+            ${catkin_EXPORTED_TARGETS})
+    target_link_libraries(knowrob-ros
+            Boost::program_options
+            ${KNOWROB_LIBRARIES}
+            knowrob
+            ${catkin_LIBRARIES}
+            ${Boost_INCLUDE_DIRS}
+            ${PYTHON_INCLUDE_DIRS}
+            ${Boost_Python_COMPONENT})
+    install(TARGETS knowrob-ros RUNTIME DESTINATION bin)
 
 
 else ()
-	message(STATUS "Building without ROS1 support.")
+    message(STATUS "Building without ROS1 support.")
 endif ()
 
 ##############
@@ -455,21 +455,21 @@ endif ()
 # where gtest won't find them without using the "--no-as-needed"
 # flag for the linker.
 add_executable(all_gtests
-		tests/gtests.cpp
-		tests/QueryParserTest.cpp
-		tests/KnowledgeBaseTest.cpp
-		tests/StorageTest.cpp
-		tests/py/test-module.cpp
-		tests/TokenBroadcasterTest.cpp
-		tests/QueryTreeTest.cpp
-		tests/DependencyGraphTest.cpp
-		tests/DataSourceTest.cpp
-		tests/ConjunctiveBroadcasterTest.cpp
-		tests/UnifierTest.cpp)
+        tests/gtests.cpp
+        tests/QueryParserTest.cpp
+        tests/KnowledgeBaseTest.cpp
+        tests/StorageTest.cpp
+        tests/py/test-module.cpp
+        tests/TokenBroadcasterTest.cpp
+        tests/QueryTreeTest.cpp
+        tests/DependencyGraphTest.cpp
+        tests/DataSourceTest.cpp
+        tests/ConjunctiveBroadcasterTest.cpp
+        tests/UnifierTest.cpp)
 add_dependencies(all_gtests knowrob_py)
 target_link_libraries(all_gtests
-		-Wl,--whole-archive,--no-as-needed
-		knowrob
-		-Wl,--no-whole-archive
-		${Boost_Python_COMPONENT}
-		${GTEST_MAIN_LIBRARIES})
+        -Wl,--whole-archive,--no-as-needed
+        knowrob
+        -Wl,--no-whole-archive
+        ${Boost_Python_COMPONENT}
+        ${GTEST_MAIN_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,11 @@ if (WITH_ROS1_INTERFACE AND catkin_FOUND AND CATKIN_DEVEL_PREFIX)
         ${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
         ${CMAKE_BINARY_DIR}/knowrob.so
         COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET knowrob_py POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CATKIN_DEVEL_PREFIX}/lib/knowrob_py.so
+        ${CATKIN_DEVEL_PREFIX}/lib/python3/dist-packages/knowrob/kb.so
+        COMMAND_EXPAND_LISTS)
 else()
     add_custom_command(TARGET knowrob_py POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy

--- a/src/integration/python/knowrob_module.cpp
+++ b/src/integration/python/knowrob_module.cpp
@@ -2,6 +2,10 @@
  * This file is part of KnowRob, please consult
  * https://github.com/knowrob/knowrob for license details.
  */
+// Check if MODULENAME is defined, and if not, define it with default "kb"
+#ifndef MODULENAME
+#define MODULENAME knowrob
+#endif
 
 #include <iostream>
 #include <functional>
@@ -72,7 +76,7 @@ static inline void register_triple_types() {
 	boost::python::class_<TripleList>("TripleList").def(boost::python::vector_indexing_suite<TripleList, true>());
 }
 
-BOOST_PYTHON_MODULE (kb) {
+BOOST_PYTHON_MODULE (MODULENAME) {
 	using namespace boost::python;
 	using namespace knowrob::py;
 

--- a/src/integration/python/knowrob_module.cpp
+++ b/src/integration/python/knowrob_module.cpp
@@ -72,7 +72,7 @@ static inline void register_triple_types() {
 	boost::python::class_<TripleList>("TripleList").def(boost::python::vector_indexing_suite<TripleList, true>());
 }
 
-BOOST_PYTHON_MODULE (knowrob) {
+BOOST_PYTHON_MODULE (kb) {
 	using namespace boost::python;
 	using namespace knowrob::py;
 

--- a/src/reasoner/owl/FactxxReasoner.py
+++ b/src/reasoner/owl/FactxxReasoner.py
@@ -1,4 +1,4 @@
-from knowrob import *
+from knowrob.kb import *
 from pyfactxx import coras
 from rdflib import BNode, URIRef, ConjunctiveGraph
 from rdflib import Literal as Literal_rdflib

--- a/src/reasoner/owl/FactxxReasoner.py
+++ b/src/reasoner/owl/FactxxReasoner.py
@@ -1,4 +1,9 @@
-from knowrob.kb import *
+try:
+	# This case works in ros1 environments
+	from knowrob.kb import *
+except ImportError:
+	# If the import fails, import the knowrob.so directly
+	from knowrob import *
 from pyfactxx import coras
 from rdflib import BNode, URIRef, ConjunctiveGraph
 from rdflib import Literal as Literal_rdflib

--- a/tests/py/test-module.cpp
+++ b/tests/py/test-module.cpp
@@ -26,7 +26,7 @@ protected:
 		try {
 			py::call<void>([&] {
 				// make sure the knowrob module is loaded, without it conversion of types won't work.
-				knowrob_module = python::import("knowrob");
+				knowrob_module = python::import("knowrob.kb");
 				test_module = python::import("tests.py.test_boost_python");
 			});
 		} catch (const std::exception& e) {

--- a/tests/py/test-module.cpp
+++ b/tests/py/test-module.cpp
@@ -49,13 +49,12 @@ protected:
 				}
 				test_module = python::import("tests.py.test_boost_python");
 			});
-		} catch (const std::exception &e) {
+		} catch (const std::exception& e) {
 			KB_ERROR("Failed to set up test suite. {}", e.what());
 		}
 	}
 
-	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name,
-								  const std::function<python::object(python::object &)> &gn) {
+	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name, const std::function<python::object(python::object &)> &gn) {
 		EXPECT_FALSE(test_module.is_none());
 		if (test_module.is_none()) { return {}; }
 
@@ -66,23 +65,21 @@ protected:
 		try {
 			return py::call<python::object>([&] { return gn(fn); });
 		} catch (const PythonError &err) {
-			GTEST_MESSAGE_AT_(file.data(), line, method_name.data(), testing::TestPartResult::kNonFatalFailure)
-					<< err.what();
+			GTEST_MESSAGE_AT_(file.data(), line, method_name.data(), testing::TestPartResult::kNonFatalFailure) << err.what();
 		}
 		return {};
 	}
 
-	static python::object
-	call(std::string_view file, uint32_t line, std::string_view method_name, const python::object &args...) {
+	static python::object call(std::string_view file, uint32_t line, std::string_view method_name, const python::object& args...) {
 		return do_call(
-				file, line, method_name,
-				[&](python::object &fn) { return fn(args); });
+			file, line, method_name,
+			[&](python::object &fn) { return fn(args); });
 	}
 
 	static python::object call(std::string_view file, uint32_t line, std::string_view method_name) {
 		return do_call(
-				file, line, method_name,
-				[&](python::object &fn) { return fn(); });
+			file, line, method_name,
+			[&](python::object &fn) { return fn(); });
 	}
 };
 
@@ -90,7 +87,7 @@ python::object BoostPythonTests::test_module;
 python::object BoostPythonTests::knowrob_module;
 
 #define EXPECT_CONVERTIBLE_TO_PY(x) EXPECT_NO_THROW( EXPECT_FALSE( \
-    py::call<bool>([&]{ return boost::python::object(x).is_none(); })))
+	py::call<bool>([&]{ return boost::python::object(x).is_none(); })))
 #define BOOST_TEST_CALL0(method_name, ...) call(__FILE__, __LINE__, method_name, __VA_ARGS__)
 #define BOOST_TEST_CALL1(method_name) call(__FILE__, __LINE__, method_name)
 
@@ -110,8 +107,8 @@ TEST_F(BoostPythonTests, string_copy_from_python) {
 	EXPECT_FALSE(boost::python::object(s).is_none());
 	auto extracted = boost::python::extract<String>(s);
 	EXPECT_TRUE(extracted.check());
-	if (extracted.check()) {
-		const auto &str = extracted();
+	if(extracted.check()) {
+		const auto& str = extracted();
 		EXPECT_EQ(str.stringForm(), "hello");
 	}
 }

--- a/tests/py/test-module.cpp
+++ b/tests/py/test-module.cpp
@@ -2,6 +2,12 @@
  * This file is part of KnowRob, please consult
  * https://github.com/knowrob/knowrob for license details.
  */
+#ifndef MODULENAME
+#define MODULENAME knowrob
+#endif
+// Macro to convert another macro's expansion to a string
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 
 #include <gtest/gtest.h>
 #include <boost/python/import.hpp>
@@ -21,20 +27,35 @@ protected:
 	static python::object knowrob_module;
 	static python::object AssertionError;
 
+
+	// Function to return the module name as a string
+	static constexpr const char *moduleNameStr() {
+		return TOSTRING(MODULENAME);
+	}
+
 	// Per-test-suite set-up.
 	static void SetUpTestSuite() {
 		try {
 			py::call<void>([&] {
 				// make sure the knowrob module is loaded, without it conversion of types won't work.
-				knowrob_module = python::import("knowrob.kb");
+				// Conditionally import module based on MODULENAME
+				if (std::string(moduleNameStr()) == "knowrob") {
+					knowrob_module = python::import("knowrob");
+					std::cout << "Loaded knowrob module" << std::endl;
+				} else {
+					std::string fullModuleName = std::string("knowrob.") + moduleNameStr();
+					knowrob_module = python::import(fullModuleName.c_str());
+					std::cout << "Loaded " << fullModuleName << " module" << std::endl;
+				}
 				test_module = python::import("tests.py.test_boost_python");
 			});
-		} catch (const std::exception& e) {
+		} catch (const std::exception &e) {
 			KB_ERROR("Failed to set up test suite. {}", e.what());
 		}
 	}
 
-	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name, const std::function<python::object(python::object&)> &gn) {
+	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name,
+								  const std::function<python::object(python::object &)> &gn) {
 		EXPECT_FALSE(test_module.is_none());
 		if (test_module.is_none()) { return {}; }
 
@@ -45,21 +66,23 @@ protected:
 		try {
 			return py::call<python::object>([&] { return gn(fn); });
 		} catch (const PythonError &err) {
-			GTEST_MESSAGE_AT_(file.data(), line, method_name.data(), testing::TestPartResult::kNonFatalFailure) << err.what();
+			GTEST_MESSAGE_AT_(file.data(), line, method_name.data(), testing::TestPartResult::kNonFatalFailure)
+					<< err.what();
 		}
 		return {};
 	}
 
-	static python::object call(std::string_view file, uint32_t line, std::string_view method_name, const python::object& args...) {
+	static python::object
+	call(std::string_view file, uint32_t line, std::string_view method_name, const python::object &args...) {
 		return do_call(
-			file, line, method_name,
-			[&](python::object &fn) { return fn(args); });
+				file, line, method_name,
+				[&](python::object &fn) { return fn(args); });
 	}
 
 	static python::object call(std::string_view file, uint32_t line, std::string_view method_name) {
 		return do_call(
-			file, line, method_name,
-			[&](python::object &fn) { return fn(); });
+				file, line, method_name,
+				[&](python::object &fn) { return fn(); });
 	}
 };
 
@@ -67,7 +90,7 @@ python::object BoostPythonTests::test_module;
 python::object BoostPythonTests::knowrob_module;
 
 #define EXPECT_CONVERTIBLE_TO_PY(x) EXPECT_NO_THROW( EXPECT_FALSE( \
-	py::call<bool>([&]{ return boost::python::object(x).is_none(); })))
+    py::call<bool>([&]{ return boost::python::object(x).is_none(); })))
 #define BOOST_TEST_CALL0(method_name, ...) call(__FILE__, __LINE__, method_name, __VA_ARGS__)
 #define BOOST_TEST_CALL1(method_name) call(__FILE__, __LINE__, method_name)
 
@@ -87,8 +110,8 @@ TEST_F(BoostPythonTests, string_copy_from_python) {
 	EXPECT_FALSE(boost::python::object(s).is_none());
 	auto extracted = boost::python::extract<String>(s);
 	EXPECT_TRUE(extracted.check());
-	if(extracted.check()) {
-		const auto& str = extracted();
+	if (extracted.check()) {
+		const auto &str = extracted();
 		EXPECT_EQ(str.stringForm(), "hello");
 	}
 }

--- a/tests/py/test_boost_python.py
+++ b/tests/py/test_boost_python.py
@@ -1,68 +1,68 @@
 try:
-    # This case works in ros1 environments
-    from knowrob.kb import *
+	# This case works in ros1 environments
+	from knowrob.kb import *
 except ImportError:
-    # If the import fails, import the knowrob.so directly
-    from knowrob import *
+	# If the import fails, import the knowrob.so directly
+	from knowrob import *
 
 
 def atom_to_python(term):
-    # make some tests that the class hierarchy is correct
-    # NOTE: unfortunately, checking the type is not enough. There are runtime conversions done
-    #       that could fail. So it makes sense to test the mapping more thoroughly for different mapped types.
-    assert isinstance(term, Term), "argument is not a Term"
-    assert isinstance(term, Atom), "argument is not an Atom"
-    # check for the existence of some methods
-    assert hasattr(term, "stringForm"), "term has no stringForm method"
-    assert hasattr(term, "variables"), "term has no variables method"
-    assert hasattr(term, "atomType"), "term has no atomType method"
-    assert hasattr(term, "atomicType"), "term has no atomicType method"
-    assert hasattr(term, "termType"), "term has no termType method"
-    assert hasattr(term, "isAtomic"), "term has no isAtomic method"
-    # check that some boolean methods return the right value
-    assert term.isAtomic(), "term is not atomic"
-    assert term.isAtom(), "term is not an atom"
-    assert not term.isVariable(), "term is a variable"
-    assert not term.isFunction(), "term is a function"
-    assert not term.isNumeric(), "term is numeric"
-    assert not term.isString(), "term is a string"
-    # check that some enums can be accessed
-    assert type(term.atomType()) == AtomType, "atomType is not an AtomType"
-    assert term.atomType() == AtomType.REGULAR, "atomType is not REGULAR"
-    assert type(term.atomicType()) == AtomicType, "atomicType is not an AtomicType"
-    assert term.atomicType() == AtomicType.ATOM, "atomicType is not ATOM"
-    assert type(term.termType()) == TermType, "termType is not a TermType"
-    assert term.termType() == TermType.ATOMIC, "termType is not ATOMIC"
-    # test that string view can be mapped to Python string
-    assert type(term.stringForm()) == str, "stringForm is not a string"
+	# make some tests that the class hierarchy is correct
+	# NOTE: unfortunately, checking the type is not enough. There are runtime conversions done
+	#       that could fail. So it makes sense to test the mapping more thoroughly for different mapped types.
+	assert isinstance(term, Term), "argument is not a Term"
+	assert isinstance(term, Atom), "argument is not an Atom"
+	# check for the existence of some methods
+	assert hasattr(term, "stringForm"), "term has no stringForm method"
+	assert hasattr(term, "variables"), "term has no variables method"
+	assert hasattr(term, "atomType"), "term has no atomType method"
+	assert hasattr(term, "atomicType"), "term has no atomicType method"
+	assert hasattr(term, "termType"), "term has no termType method"
+	assert hasattr(term, "isAtomic"), "term has no isAtomic method"
+	# check that some boolean methods return the right value
+	assert term.isAtomic(), "term is not atomic"
+	assert term.isAtom(), "term is not an atom"
+	assert not term.isVariable(), "term is a variable"
+	assert not term.isFunction(), "term is a function"
+	assert not term.isNumeric(), "term is numeric"
+	assert not term.isString(), "term is a string"
+	# check that some enums can be accessed
+	assert type(term.atomType()) == AtomType, "atomType is not an AtomType"
+	assert term.atomType() == AtomType.REGULAR, "atomType is not REGULAR"
+	assert type(term.atomicType()) == AtomicType, "atomicType is not an AtomicType"
+	assert term.atomicType() == AtomicType.ATOM, "atomicType is not ATOM"
+	assert type(term.termType()) == TermType, "termType is not a TermType"
+	assert term.termType() == TermType.ATOMIC, "termType is not ATOMIC"
+	# test that string view can be mapped to Python string
+	assert type(term.stringForm()) == str, "stringForm is not a string"
 
 
 def modify_triple_in_python(triple):
-    assert isinstance(triple, FramedTriple), "argument is not a FramedTriple"
-    assert hasattr(triple, "setSubject"), "term has no setSubject method"
-    assert hasattr(triple, "setPredicate"), "term has no setPredicate method"
-    triple.setSubject("olleh")
-    triple.setPredicate("swonk")
+	assert isinstance(triple, FramedTriple), "argument is not a FramedTriple"
+	assert hasattr(triple, "setSubject"), "term has no setSubject method"
+	assert hasattr(triple, "setPredicate"), "term has no setPredicate method"
+	triple.setSubject("olleh")
+	triple.setPredicate("swonk")
 
 
 def string_copy_from_python():
-    # test that string can be copied from Python to C++.
-    # here the constructor actually takes a string_view argument which is then copied internally.
-    term = String("hello")
-    assert term is not None, "term is None"
-    assert term.stringForm() == "hello", "stringForm is not 'hello'"
-    return term
+	# test that string can be copied from Python to C++.
+	# here the constructor actually takes a string_view argument which is then copied internally.
+	term = String("hello")
+	assert term is not None, "term is None"
+	assert term.stringForm() == "hello", "stringForm is not 'hello'"
+	return term
 
 
 def optional_is_none(optional):
-    assert optional is None, "optional is not None"
+	assert optional is None, "optional is not None"
 
 
 def optional_is_not_none(optional):
-    assert optional is not None, "optional is None"
+	assert optional is not None, "optional is None"
 
 
 def set_xsd_optional(optional):
-    assert optional == XSDType.STRING, "optional is not STRING"
-    optional = XSDType.DOUBLE
-    assert optional == XSDType.DOUBLE, "optional is not DOUBLE"
+	assert optional == XSDType.STRING, "optional is not STRING"
+	optional = XSDType.DOUBLE
+	assert optional == XSDType.DOUBLE, "optional is not DOUBLE"

--- a/tests/py/test_boost_python.py
+++ b/tests/py/test_boost_python.py
@@ -1,63 +1,68 @@
-from knowrob.kb import *
+try:
+    # This case works in ros1 environments
+    from knowrob.kb import *
+except ImportError:
+    # If the import fails, import the knowrob.so directly
+    from knowrob import *
 
 
 def atom_to_python(term):
-	# make some tests that the class hierarchy is correct
-	# NOTE: unfortunately, checking the type is not enough. There are runtime conversions done
-	#       that could fail. So it makes sense to test the mapping more thoroughly for different mapped types.
-	assert isinstance(term, Term), "argument is not a Term"
-	assert isinstance(term, Atom), "argument is not an Atom"
-	# check for the existence of some methods
-	assert hasattr(term, "stringForm"), "term has no stringForm method"
-	assert hasattr(term, "variables"), "term has no variables method"
-	assert hasattr(term, "atomType"), "term has no atomType method"
-	assert hasattr(term, "atomicType"), "term has no atomicType method"
-	assert hasattr(term, "termType"), "term has no termType method"
-	assert hasattr(term, "isAtomic"), "term has no isAtomic method"
-	# check that some boolean methods return the right value
-	assert term.isAtomic(), "term is not atomic"
-	assert term.isAtom(), "term is not an atom"
-	assert not term.isVariable(), "term is a variable"
-	assert not term.isFunction(), "term is a function"
-	assert not term.isNumeric(), "term is numeric"
-	assert not term.isString(), "term is a string"
-	# check that some enums can be accessed
-	assert type(term.atomType()) == AtomType, "atomType is not an AtomType"
-	assert term.atomType() == AtomType.REGULAR, "atomType is not REGULAR"
-	assert type(term.atomicType()) == AtomicType, "atomicType is not an AtomicType"
-	assert term.atomicType() == AtomicType.ATOM, "atomicType is not ATOM"
-	assert type(term.termType()) == TermType, "termType is not a TermType"
-	assert term.termType() == TermType.ATOMIC, "termType is not ATOMIC"
-	# test that string view can be mapped to Python string
-	assert type(term.stringForm()) == str, "stringForm is not a string"
+    # make some tests that the class hierarchy is correct
+    # NOTE: unfortunately, checking the type is not enough. There are runtime conversions done
+    #       that could fail. So it makes sense to test the mapping more thoroughly for different mapped types.
+    assert isinstance(term, Term), "argument is not a Term"
+    assert isinstance(term, Atom), "argument is not an Atom"
+    # check for the existence of some methods
+    assert hasattr(term, "stringForm"), "term has no stringForm method"
+    assert hasattr(term, "variables"), "term has no variables method"
+    assert hasattr(term, "atomType"), "term has no atomType method"
+    assert hasattr(term, "atomicType"), "term has no atomicType method"
+    assert hasattr(term, "termType"), "term has no termType method"
+    assert hasattr(term, "isAtomic"), "term has no isAtomic method"
+    # check that some boolean methods return the right value
+    assert term.isAtomic(), "term is not atomic"
+    assert term.isAtom(), "term is not an atom"
+    assert not term.isVariable(), "term is a variable"
+    assert not term.isFunction(), "term is a function"
+    assert not term.isNumeric(), "term is numeric"
+    assert not term.isString(), "term is a string"
+    # check that some enums can be accessed
+    assert type(term.atomType()) == AtomType, "atomType is not an AtomType"
+    assert term.atomType() == AtomType.REGULAR, "atomType is not REGULAR"
+    assert type(term.atomicType()) == AtomicType, "atomicType is not an AtomicType"
+    assert term.atomicType() == AtomicType.ATOM, "atomicType is not ATOM"
+    assert type(term.termType()) == TermType, "termType is not a TermType"
+    assert term.termType() == TermType.ATOMIC, "termType is not ATOMIC"
+    # test that string view can be mapped to Python string
+    assert type(term.stringForm()) == str, "stringForm is not a string"
 
 
 def modify_triple_in_python(triple):
-	assert isinstance(triple, FramedTriple), "argument is not a FramedTriple"
-	assert hasattr(triple, "setSubject"), "term has no setSubject method"
-	assert hasattr(triple, "setPredicate"), "term has no setPredicate method"
-	triple.setSubject("olleh")
-	triple.setPredicate("swonk")
+    assert isinstance(triple, FramedTriple), "argument is not a FramedTriple"
+    assert hasattr(triple, "setSubject"), "term has no setSubject method"
+    assert hasattr(triple, "setPredicate"), "term has no setPredicate method"
+    triple.setSubject("olleh")
+    triple.setPredicate("swonk")
 
 
 def string_copy_from_python():
-	# test that string can be copied from Python to C++.
-	# here the constructor actually takes a string_view argument which is then copied internally.
-	term = String("hello")
-	assert term is not None, "term is None"
-	assert term.stringForm() == "hello", "stringForm is not 'hello'"
-	return term
+    # test that string can be copied from Python to C++.
+    # here the constructor actually takes a string_view argument which is then copied internally.
+    term = String("hello")
+    assert term is not None, "term is None"
+    assert term.stringForm() == "hello", "stringForm is not 'hello'"
+    return term
 
 
 def optional_is_none(optional):
-	assert optional is None, "optional is not None"
+    assert optional is None, "optional is not None"
 
 
 def optional_is_not_none(optional):
-	assert optional is not None, "optional is None"
+    assert optional is not None, "optional is None"
 
 
 def set_xsd_optional(optional):
-	assert optional == XSDType.STRING, "optional is not STRING"
-	optional = XSDType.DOUBLE
-	assert optional == XSDType.DOUBLE, "optional is not DOUBLE"
+    assert optional == XSDType.STRING, "optional is not STRING"
+    optional = XSDType.DOUBLE
+    assert optional == XSDType.DOUBLE, "optional is not DOUBLE"

--- a/tests/py/test_boost_python.py
+++ b/tests/py/test_boost_python.py
@@ -1,4 +1,4 @@
-from knowrob import *
+from knowrob.kb import *
 
 
 def atom_to_python(term):


### PR DESCRIPTION
This pull request fixes the unit tests in CI, and therefore also in ros1 environments. 

In ROS we had the problem that ROS already generated a knowrob python module (e.g. containing the msg), which clashed with the naming of the knowrob.so. Therefore we rename the shared library in that case to kb.so and add it as a submodule to the catkin generated python module. 

Additonally I slightly changed the CI, so that it fails if the test fail. See for example this run, where i tested it:

https://github.com/sasjonge/knowrob/actions/runs/9111601623/job/25049599287