### PR TITLE
Fix for "cannot set frequency" warning

### DIFF
--- a/src/semweb/Vocabulary.cpp
+++ b/src/semweb/Vocabulary.cpp
@@ -25,6 +25,7 @@ Vocabulary::Vocabulary()
 	defineProperty(rdf::type);
 	defineProperty(rdfs::subPropertyOf);
 	defineProperty(rdfs::subClassOf);
+	defineProperty(owl::inverseOf);
 }
 
 bool Vocabulary::isDefinedClass(const std::string_view &iri) {


### PR DESCRIPTION
When running the unit tests one gets this warning:

`[14:45:48.868] [warning] cannot set frequency of unknown resource 'http://www.w3.org/2002/07/owl#inverseOf'`

This is fixed by adding inverseOf to the defined properties