### PR TITLE
Fix to AskIncremental ROS Services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,12 @@ if (WITH_ROS1_INTERFACE AND catkin_FOUND)
             Tell.action
     )
 
+    add_service_files(
+            DIRECTORY ros1/srv
+            FILES
+            AskIncrementalFinish.srv
+    )
+
     generate_messages(DEPENDENCIES
             std_msgs
             actionlib_msgs)

--- a/include/knowrob/integration/ros1/ROSInterface.h
+++ b/include/knowrob/integration/ros1/ROSInterface.h
@@ -26,6 +26,7 @@
 #include <knowrob/AskOneAction.h>
 #include <knowrob/AskIncrementalAction.h>
 #include <knowrob/AskIncrementalNextSolutionAction.h>
+#include <knowrob/AskIncrementalFinish.h>
 #include <knowrob/TellAction.h>
 #include <actionlib/server/simple_action_server.h>
 // std
@@ -42,6 +43,9 @@ namespace knowrob {
 		actionlib::SimpleActionServer<AskIncrementalAction> askincremental_action_server_;
 		actionlib::SimpleActionServer<AskIncrementalNextSolutionAction> askincremental_next_solution_action_server_;
 		actionlib::SimpleActionServer<TellAction> tell_action_server_;
+
+		// ROS Services
+		ros::ServiceServer ask_incremental_finish_service_;
 
 		// KnowledgeBase
 		KnowledgeBase kb_;
@@ -92,6 +96,15 @@ namespace knowrob {
 		 * @param goal TellGoalConstPtr
 		 */
 		void executeTellCB(const TellGoalConstPtr &goal);
+
+		/**
+		 * Handle the AskIncrementalFinish service
+		 * @param req AskIncrementalFinish::Request
+		 * @param res AskIncrementalFinish::Response
+		 * @return true if the service was handled successfully
+		 */
+		bool handleAskIncrementalFinish(AskIncrementalFinish::Request &req,
+										AskIncrementalFinish::Response &res);
 
 		/**
 		 * Translate a GraphQueryMessage into a map of key-value pairs

--- a/ros1/srv/AskIncrementalFinish.srv
+++ b/ros1/srv/AskIncrementalFinish.srv
@@ -1,0 +1,3 @@
+uint32 queryId
+---
+bool success


### PR DESCRIPTION
The AskIncremental ROS Action Services had a bug, where only the last result was the result, stemming from a missing break command. This is fixed by removing the loop. 

I also added a removal of finished ids for queries and added a service to manually finish the id to allow memory management by the user.

I tested the implementation locally, especially also the case when an queryID is "finished" (either because no answers are left, or because a user did manually set it to finish).