### PR TITLE
Work on GoalDrivenReasoner interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,8 @@ add_library(knowrob SHARED
         src/reasoner/GoalDrivenReasoner.cpp
         src/reasoner/DataDrivenReasoner.cpp
         src/reasoner/ReasonerEvent.cpp
-        src/ontologies/TransformedOntology.cpp)
+        src/ontologies/TransformedOntology.cpp
+        src/reasoner/ReasonerQuery.cpp)
 set(KNOWROB_LIBRARIES
         ${SWIPL_LIBRARIES}
         ${MONGOC_LIBRARIES}

--- a/include/knowrob/reasoner/GoalDrivenReasoner.h
+++ b/include/knowrob/reasoner/GoalDrivenReasoner.h
@@ -7,7 +7,7 @@
 #define KNOWROB_GOAL_DRIVEN_REASONER_H
 
 #include "Reasoner.h"
-#include "knowrob/queries/TokenBuffer.h"
+#include "ReasonerQuery.h"
 #include "knowrob/formulas/PredicateIndicator.h"
 
 namespace knowrob {
@@ -45,18 +45,33 @@ namespace knowrob {
 		void unDefineRelation(const PredicateIndicator &indicator) { definedRelations_.erase(indicator); }
 
 		/**
-		 * Submit a query to the reasoner.
+		 * Evaluate a query with a reasoner.
 		 * The query is represented by a literal and a context.
-		 * The evaluation of the query is performed asynchronously, the result of this function
-		 * is a buffer that can be used to retrieve the results of the query at a later point in time.
+		 * The evaluation of the query must be performed synchronously.
+		 * A reasoner may throw an exception if the query cannot be evaluated,
+		 * or return false to also indicate an error status.
 		 * @param literal a literal representing the query.
 		 * @param ctx a query context.
 		 * @return a buffer that can be used to retrieve the results of the query.
 		 */
-		virtual TokenBufferPtr submitQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx) = 0;
+		virtual bool evaluateQuery(ReasonerQueryPtr query) = 0;
 
 	protected:
 		std::set<PredicateIndicator> definedRelations_;
+	};
+
+	/**
+	 * A runner that can be used to evaluate a query in a thread pool.
+	 */
+	class ReasonerRunner : public ThreadPool::Runner {
+	public:
+		std::shared_ptr<GoalDrivenReasoner> reasoner;
+		std::shared_ptr<ReasonerQuery> query;
+
+		ReasonerRunner() = default;
+
+		// ThreadPool::Runner interface
+		void run() override;
 	};
 
 	using GoalDrivenReasonerPtr = std::shared_ptr<GoalDrivenReasoner>;

--- a/include/knowrob/reasoner/ReasonerManager.h
+++ b/include/knowrob/reasoner/ReasonerManager.h
@@ -67,6 +67,18 @@ namespace knowrob {
 		std::shared_ptr<NamedReasoner>
 		addPlugin(std::string_view reasonerID, const std::shared_ptr<Reasoner> &reasoner) override;
 
+		/**
+		 * Evaluate a query using a goal-driven reasoner.
+		 * @param reasoner the reasoner to use.
+		 * @param literal the query to evaluate.
+		 * @param ctx the query context.
+		 * @return a buffer that can be used to retrieve the results of the query.
+		 */
+		static TokenBufferPtr evaluateQuery(
+				const GoalDrivenReasonerPtr &reasoner,
+				const FramedTriplePatternPtr &literal,
+				const QueryContextPtr &ctx);
+
 	private:
 		KnowledgeBase *kb_;
 		std::shared_ptr<StorageManager> backendManager_;

--- a/include/knowrob/reasoner/ReasonerQuery.h
+++ b/include/knowrob/reasoner/ReasonerQuery.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#ifndef KNOWROB_REASONER_QUERY_H_
+#define KNOWROB_REASONER_QUERY_H_
+
+#include <ostream>
+#include <utility>
+#include <knowrob/triples/FramedTriplePattern.h>
+#include <knowrob/queries/TokenBuffer.h>
+#include <knowrob/queries/Answer.h>
+
+namespace knowrob {
+	/**
+	 */
+	class ReasonerQuery : public Query {
+	public:
+		/**
+		 * @param ctx the query context.
+		 */
+		explicit ReasonerQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx = DefaultQueryContext());
+
+		~ReasonerQuery() override;
+
+		/**
+		 * @return the literal.
+		 */
+		auto &literal() const { return literal_; }
+
+		/**
+		 * Pushes an answer into the output channel.
+		 * @param answer an answer.
+		 */
+		void push(const AnswerPtr &answer) { outputChannel_->push(answer); }
+
+		/**
+		 * Indicates that the evaluation has finished.
+		 */
+		void finish() { outputChannel_->push(EndOfEvaluation::get()); }
+
+		/**
+		 * @return the answer buffer.
+		 */
+		auto &answerBuffer() const { return answerBuffer_; }
+
+	protected:
+		std::shared_ptr<const QueryContext> ctx_;
+		std::shared_ptr<TokenBuffer> answerBuffer_;
+		std::shared_ptr<TokenStream::Channel> outputChannel_;
+		std::shared_ptr<FramedTriplePattern> literal_;
+
+		// Override Query
+		void write(std::ostream &os) const override { os << *literal_; }
+	};
+
+	using ReasonerQueryPtr = std::shared_ptr<ReasonerQuery>;
+}
+
+#endif //KNOWROB_REASONER_QUERY_H_

--- a/include/knowrob/reasoner/prolog/PrologReasoner.h
+++ b/include/knowrob/reasoner/prolog/PrologReasoner.h
@@ -80,7 +80,7 @@ namespace knowrob {
 		void setDataBackend(const StoragePtr &backend) override;
 
 		// Override Reasoner
-		TokenBufferPtr submitQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx) override;
+		bool evaluateQuery(ReasonerQueryPtr query) override;
 
 	protected:
 		static bool isKnowRobInitialized_;

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -71,7 +71,7 @@ bool PredicateNegationStage::succeeds(const AnswerYesPtr &answer) {
 		auto l_reasoner = kb_->reasonerManager()->getReasonerForRelation(
 				PredicateIndicator(l_property_a->stringForm(), 2));
 		for (auto &r: l_reasoner) {
-			results.push_back(r->submitQuery(instance, ctx_));
+			results.push_back(ReasonerManager::evaluateQuery(r, instance, ctx_));
 		}
 	}
 

--- a/src/queries/QueryPipeline.cpp
+++ b/src/queries/QueryPipeline.cpp
@@ -481,7 +481,7 @@ void QueryPipeline::createComputationPipeline(
 			auto idbStage = std::make_shared<TypedQueryStage<FramedTriplePattern>>(
 					ctx, lit,
 					[&r, &ctx](const FramedTriplePatternPtr &q) {
-						return r->submitQuery(q, ctx);
+						return ReasonerManager::evaluateQuery(r, q, ctx);
 					});
 			idbStage->selfWeakRef_ = idbStage;
 			stepInput >> idbStage;

--- a/src/reasoner/GoalDrivenReasoner.cpp
+++ b/src/reasoner/GoalDrivenReasoner.cpp
@@ -8,6 +8,14 @@
 
 using namespace knowrob;
 
+void ReasonerRunner::run() {
+	if (!reasoner->evaluateQuery(query)) {
+		KB_WARN("Reasoner {} produced 'false' in query evaluation for query: {}",
+				 *reasoner->reasonerName(), *query->literal());
+	}
+	query->finish();
+}
+
 namespace knowrob::py {
 	// this struct is needed because Reasoner has pure virtual methods
 	struct GoalDrivenReasonerWrap : public GoalDrivenReasoner, boost::python::wrapper<GoalDrivenReasoner> {
@@ -21,8 +29,8 @@ namespace knowrob::py {
 			return call_method<bool>(self, "initializeReasoner", config);
 		}
 
-		TokenBufferPtr submitQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx) override {
-			return call_method<TokenBufferPtr>(self, "submitQuery", literal, ctx);
+		bool evaluateQuery(ReasonerQueryPtr query) override {
+			return call_method<bool>(self, "evaluateQuery", query);
 		}
 
 	private:
@@ -38,6 +46,8 @@ namespace knowrob::py {
 				.def("defineRelation", &GoalDrivenReasoner::defineRelation)
 				.def("unDefineRelation", &GoalDrivenReasoner::unDefineRelation)
 						// methods that must be implemented by reasoner plugins
-				.def("submitQuery", &GoalDrivenReasonerWrap::submitQuery);
+				.def("evaluateQuery", &GoalDrivenReasonerWrap::evaluateQuery);
+
+		createType<ReasonerQuery>();
 	}
 }

--- a/src/reasoner/ReasonerQuery.cpp
+++ b/src/reasoner/ReasonerQuery.cpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#include "knowrob/reasoner/ReasonerQuery.h"
+#include "knowrob/integration/python/utils.h"
+
+using namespace knowrob;
+
+ReasonerQuery::ReasonerQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx)
+		: Query(ctx),
+		  literal_(std::move(literal)),
+		  ctx_(std::move(ctx)),
+		  answerBuffer_(std::make_shared<TokenBuffer>()),
+		  outputChannel_(TokenStream::Channel::create(answerBuffer_)) {}
+
+ReasonerQuery::~ReasonerQuery() {
+	outputChannel_->close();
+}
+
+namespace knowrob::py {
+	template<>
+	void createType<ReasonerQuery>() {
+		using namespace boost::python;
+
+		class_<ReasonerQuery, std::shared_ptr<ReasonerQuery>, boost::noncopyable>
+				("ReasonerQuery", init<FramedTriplePatternPtr, QueryContextPtr>())
+				.def("literal", &ReasonerQuery::literal, return_value_policy<copy_const_reference>())
+				.def("answerBuffer", &ReasonerQuery::answerBuffer, return_value_policy<copy_const_reference>())
+				.def("ctx", &Query::ctx, return_value_policy<copy_const_reference>())
+				.def("push", &ReasonerQuery::push);
+	}
+}

--- a/src/reasoner/esg/parser.pl
+++ b/src/reasoner/esg/parser.pl
@@ -121,13 +121,13 @@ parser_create_grammar_(Parser,WF) :-
   ), Steps),
   list_to_set(Steps,Steps0),
   findall(C, (
-    member(X,Steps0),
+    member(X,[Tsk|Steps0]),
     interval_constraint(X,C,Other),
     once(member(Other,Steps0))
   ), Constraints),
   list_to_set(Constraints,Constraints0),
   % compute the sequence graph
-  parser_info_(loading_grammar(WF,Constraints0)),
+  parser_info_(loading_grammar(plan(WF),tsk(Tsk))),
   esg_truncated(Tsk,Steps0,Constraints0,[Sequence,
                            PreConditions, PostConditions]),
   % assert to Prolog KB

--- a/src/reasoner/prolog/PrologReasoner.cpp
+++ b/src/reasoner/prolog/PrologReasoner.cpp
@@ -181,22 +181,21 @@ bool PrologReasoner::load_rdf_xml(const std::filesystem::path &rdfFile) {
 	return PROLOG_REASONER_EVAL(PrologTerm(load_rdf_xml_f, path.native(), reasonerName()));
 }
 
-TokenBufferPtr PrologReasoner::submitQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx) {
+bool PrologReasoner::evaluateQuery(ReasonerQueryPtr query) {
 	// context term options:
 	static const auto query_scope_f = "query_scope";
 	static const auto solution_scope_f = "solution_scope";
 	static const auto triple_f = "triple";
 
-	auto answerBuffer = std::make_shared<TokenBuffer>();
-	auto outputChannel = TokenStream::Channel::create(answerBuffer);
-
-	// create runner that evaluates the goal in a thread with a Prolog engine
+	// create runner that evaluates the goal in a thread with a Prolog engine.
+	// Note that this is needed because the current thread might not have
+	// a Prolog engine associated with it.
 	auto runner = std::make_shared<ThreadPool::LambdaRunner>(
-			[this,literal,outputChannel,ctx](const ThreadPool::LambdaRunner::StopChecker &hasStopRequest) {
+			[this,query](const ThreadPool::LambdaRunner::StopChecker &hasStopRequest) {
 				PrologTerm queryFrame, answerFrame;
-				putQueryFrame(queryFrame, ctx->selector);
+				putQueryFrame(queryFrame, query->ctx()->selector);
 
-				PrologTerm rdfGoal(*literal, triple_f);
+				PrologTerm goal(*query->literal(), triple_f);
 				// :- ContextTerm = [query_scope(...), solution_scope(Variable)]
 				PrologList contextTerm({
 											   PrologTerm(query_scope_f, queryFrame),
@@ -204,29 +203,31 @@ TokenBufferPtr PrologReasoner::submitQuery(FramedTriplePatternPtr literal, Query
 									   });
 				// :- QueryGoal = ( b_setval(reasoner_module, reasonerName()),
 				//                  b_setval(reasoner_manager, managerID),
-				//                  reasoner_call(LiteralGoal, ContextTerm) ).
+				//                  reasoner_call(Goal, ContextTerm) ).
 				PrologTerm queryGoal = getReasonerQuery(
-						PrologTerm(callFunctor(), rdfGoal, contextTerm));
+						PrologTerm(callFunctor(), goal, contextTerm));
 
 				auto qid = queryGoal.openQuery(prologQueryFlags);
 				bool hasSolution = false;
-				while (!hasStopRequest() && queryGoal.nextSolution(qid)) {
-					outputChannel->push(yes(literal, rdfGoal, answerFrame));
+				while (!hasStopRequest() && knowrob::PrologTerm::nextSolution(qid)) {
+					query->push(yes(query->literal(), goal, answerFrame));
 					hasSolution = true;
-					if (ctx->queryFlags & QUERY_FLAG_ONE_SOLUTION) break;
+					if (query->ctx()->queryFlags & QUERY_FLAG_ONE_SOLUTION) break;
 				}
 				PL_close_query(qid);
-				if (!hasSolution) outputChannel->push(no(literal));
-				outputChannel->push(EndOfEvaluation::get());
+				if (!hasSolution) query->push(no(query->literal()));
 			});
 
 	// push goal and return
-	PrologEngine::pushGoal(runner, [literal, outputChannel](const std::exception &e) {
-		KB_WARN("an exception occurred for prolog query ({}): {}.", *literal, e.what());
-		outputChannel->close();
+	PrologEngine::pushGoal(runner, [query](const std::exception &e) {
+		KB_WARN("an exception occurred for prolog query ({}): {}.", *query->literal(), e.what());
+		throw;
 	});
 
-	return answerBuffer;
+	// evaluateQuery must be blocking -> wait on Prolog runner to finish
+	runner->join();
+
+	return true;
 }
 
 AnswerYesPtr PrologReasoner::yes(const FramedTriplePatternPtr &literal,

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -45,9 +45,8 @@ public:
 	bool initializeReasoner(const PropertyTree &cfg) override { return true; }
 	void setDataBackend(const StoragePtr &backend) override {}
 
-	TokenBufferPtr submitQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx) override {
-		auto answerBuffer = std::make_shared<TokenBuffer>();
-		auto outputChannel = TokenStream::Channel::create(answerBuffer);
+	bool evaluateQuery(ReasonerQueryPtr query) override {
+		auto literal = query->literal();
 
 		bool succeed = true;
 		if(literal->propertyTerm()->isGround()) {
@@ -75,11 +74,10 @@ public:
 				bindings->set(std::make_shared<Variable>(v), IRIAtom::Tabled(o_));
 			}
 			auto answer = std::make_shared<AnswerYes>(bindings);
-			outputChannel->push(answer);
+			query->push(answer);
 		}
 
-		outputChannel->push(EndOfEvaluation::get());
-		return answerBuffer;
+		return true;
 	}
 };
 

--- a/tests/reasoner/dummy_reasoner.py
+++ b/tests/reasoner/dummy_reasoner.py
@@ -34,5 +34,5 @@ class DummyReasoner(ReasonerWithBackend):
 		print("getDescription: " + str(indicator))
 		return None
 
-	def submitQuery(self, query, ctx):
+	def evaluateQuery(self, query):
 		return None


### PR DESCRIPTION
The interface is simplified and renamed from `submitQuery` to `evaluateQuery`.
Main points are:
- reasoner do not need to deal with `TokenBuffer` etc, and they do not need to send a STOP token to indicate they are done
- the threading is now done centrally such that every reasoner runs in a worker thread