### PR TITLE
Revised interface for GoalDrivenReasoner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,8 @@ add_library(knowrob SHARED
         src/reasoner/DataDrivenReasoner.cpp
         src/reasoner/ReasonerEvent.cpp
         src/ontologies/TransformedOntology.cpp
-        src/reasoner/ReasonerQuery.cpp)
+        src/reasoner/ReasonerQuery.cpp
+        src/formulas/SimpleConjunction.cpp)
 set(KNOWROB_LIBRARIES
         ${SWIPL_LIBRARIES}
         ${MONGOC_LIBRARIES}

--- a/include/knowrob/formulas/SimpleConjunction.h
+++ b/include/knowrob/formulas/SimpleConjunction.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#ifndef KNOWROB_SIMPLE_CONJUNCTION_H
+#define KNOWROB_SIMPLE_CONJUNCTION_H
+
+#include "Conjunction.h"
+#include "FirstOrderLiteral.h"
+
+namespace knowrob {
+	/**
+	 * A conjunction of literals.
+	 */
+	class SimpleConjunction : public Conjunction {
+	public:
+		/**
+		 * @param literals sequence of literals in conjunction.
+		 */
+		explicit SimpleConjunction(const std::vector<FirstOrderLiteral> &literals);
+
+		/**
+		 * @return sequence of literals in conjunction.
+		 */
+		auto &literals() const { return literals_; }
+
+	protected:
+		std::vector<FirstOrderLiteral> literals_;
+	};
+
+} // knowrob
+
+#endif //KNOWROB_SIMPLE_CONJUNCTION_H

--- a/include/knowrob/formulas/SimpleConjunction.h
+++ b/include/knowrob/formulas/SimpleConjunction.h
@@ -18,7 +18,12 @@ namespace knowrob {
 		/**
 		 * @param literals sequence of literals in conjunction.
 		 */
-		explicit SimpleConjunction(const std::vector<FirstOrderLiteral> &literals);
+		explicit SimpleConjunction(const std::vector<FirstOrderLiteralPtr> &literals);
+
+		/**
+		 * @param literal a literal.
+		 */
+		explicit SimpleConjunction(const FirstOrderLiteralPtr &literal);
 
 		/**
 		 * @return sequence of literals in conjunction.
@@ -26,8 +31,10 @@ namespace knowrob {
 		auto &literals() const { return literals_; }
 
 	protected:
-		std::vector<FirstOrderLiteral> literals_;
+		std::vector<FirstOrderLiteralPtr> literals_;
 	};
+
+	using SimpleConjunctionPtr = std::shared_ptr<SimpleConjunction>;
 
 } // knowrob
 

--- a/include/knowrob/reasoner/GoalDrivenReasoner.h
+++ b/include/knowrob/reasoner/GoalDrivenReasoner.h
@@ -12,6 +12,17 @@
 
 namespace knowrob {
 	/**
+	 * An enumeration of reasoner features for goal-driven reasoning.
+	 */
+	enum class GoalDrivenReasonerFeature {
+		/**
+		 * The reasoner supports simple conjunctions.
+		 * A simple conjunction is a conjunction of literals.
+		 */
+		SupportsSimpleConjunctions = 0x01,
+	};
+
+	/**
 	 * A reasoner that supports goal-driven reasoning.
 	 * Goal-driven reasoning is a form of reasoning where the reasoner is asked to evaluate a query.
 	 * This is in contrast to data-driven reasoning, where the reasoner is started and then infers
@@ -19,7 +30,19 @@ namespace knowrob {
 	 */
 	class GoalDrivenReasoner : public Reasoner {
 	public:
-		GoalDrivenReasoner() : Reasoner() {}
+		GoalDrivenReasoner() : Reasoner(), features_(0) {}
+
+		~GoalDrivenReasoner() override = default;
+
+		/**
+		 * @return true if the reasoner supports a specific feature.
+		 */
+		bool hasFeature(GoalDrivenReasonerFeature feature) const;
+
+		/**
+		 * Enable a specific feature of the reasoner.
+		 */
+		void enableFeature(GoalDrivenReasonerFeature feature);
 
 		/**
 		 * Find out if the relation is defined by this reasoner.
@@ -46,18 +69,20 @@ namespace knowrob {
 
 		/**
 		 * Evaluate a query with a reasoner.
-		 * The query is represented by a literal and a context.
-		 * The evaluation of the query must be performed synchronously.
-		 * A reasoner may throw an exception if the query cannot be evaluated,
+		 * The query is represented by a formula, a context and an answer queue
+		 * where results of the reasoning process can be added.
+		 * The evaluation of the query must be performed synchronously,
+		 * i.e. the answer queue must be filled before the function returns.
+		 * A reasoner may instead throw an exception if the query cannot be evaluated,
 		 * or return false to also indicate an error status.
-		 * @param literal a literal representing the query.
-		 * @param ctx a query context.
-		 * @return a buffer that can be used to retrieve the results of the query.
+		 * @param query the query to evaluate.
+		 * @return true on success, false otherwise.
 		 */
 		virtual bool evaluateQuery(ReasonerQueryPtr query) = 0;
 
 	protected:
 		std::set<PredicateIndicator> definedRelations_;
+		int features_;
 	};
 
 	/**

--- a/include/knowrob/reasoner/ReasonerManager.h
+++ b/include/knowrob/reasoner/ReasonerManager.h
@@ -76,7 +76,7 @@ namespace knowrob {
 		 */
 		static TokenBufferPtr evaluateQuery(
 				const GoalDrivenReasonerPtr &reasoner,
-				const FramedTriplePatternPtr &literal,
+				const FirstOrderLiteralPtr &literal,
 				const QueryContextPtr &ctx);
 
 	private:

--- a/include/knowrob/reasoner/ReasonerQuery.h
+++ b/include/knowrob/reasoner/ReasonerQuery.h
@@ -11,23 +11,32 @@
 #include <knowrob/triples/FramedTriplePattern.h>
 #include <knowrob/queries/TokenBuffer.h>
 #include <knowrob/queries/Answer.h>
+#include "knowrob/formulas/SimpleConjunction.h"
 
 namespace knowrob {
 	/**
+	 * A query that can be submitted to a reasoner.
 	 */
 	class ReasonerQuery : public Query {
 	public:
 		/**
-		 * @param ctx the query context.
+		 * @param formula a formula.
+		 * @param ctx a query context.
 		 */
-		explicit ReasonerQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx = DefaultQueryContext());
+		explicit ReasonerQuery(SimpleConjunctionPtr formula, QueryContextPtr ctx = DefaultQueryContext());
+
+		/**
+		 * @param literal a literal.
+		 * @param ctx a query context.
+		 */
+		explicit ReasonerQuery(const FirstOrderLiteralPtr &literal, QueryContextPtr ctx = DefaultQueryContext());
 
 		~ReasonerQuery() override;
 
 		/**
 		 * @return the literal.
 		 */
-		auto &literal() const { return literal_; }
+		auto &formula() const { return formula_; }
 
 		/**
 		 * Pushes an answer into the output channel.
@@ -49,10 +58,10 @@ namespace knowrob {
 		std::shared_ptr<const QueryContext> ctx_;
 		std::shared_ptr<TokenBuffer> answerBuffer_;
 		std::shared_ptr<TokenStream::Channel> outputChannel_;
-		std::shared_ptr<FramedTriplePattern> literal_;
+		std::shared_ptr<SimpleConjunction> formula_;
 
 		// Override Query
-		void write(std::ostream &os) const override { os << *literal_; }
+		void write(std::ostream &os) const override { os << *formula_; }
 	};
 
 	using ReasonerQueryPtr = std::shared_ptr<ReasonerQuery>;

--- a/include/knowrob/reasoner/prolog/PrologReasoner.h
+++ b/include/knowrob/reasoner/prolog/PrologReasoner.h
@@ -94,9 +94,9 @@ namespace knowrob {
 			return consult(dataFile->uri());
 		};
 
-		AnswerYesPtr yes(const FramedTriplePatternPtr &literal, const PrologTerm &rdfGoal, const PrologTerm &frameTerm);
+		AnswerYesPtr yes(const ReasonerQueryPtr &query, const PrologTerm &rdfGoal, const PrologTerm &frameTerm);
 
-		AnswerNoPtr no(const FramedTriplePatternPtr &literal);
+		AnswerNoPtr no(const ReasonerQueryPtr &query);
 
 		static bool putQueryFrame(PrologTerm &frameTerm, const GraphSelector &frame);
 

--- a/src/formulas/Conjunction.cpp
+++ b/src/formulas/Conjunction.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <knowrob/formulas/Conjunction.h>
 #include "knowrob/integration/python/utils.h"
+#include "knowrob/formulas/SimpleConjunction.h"
 
 using namespace knowrob;
 
@@ -61,5 +62,7 @@ namespace knowrob::py {
 		using namespace boost::python;
 		class_<Conjunction, std::shared_ptr<Conjunction>, bases<CompoundFormula>>
 				("Conjunction", init<const std::vector<FormulaPtr> &>());
+
+		createType<SimpleConjunction>();
 	}
 }

--- a/src/formulas/SimpleConjunction.cpp
+++ b/src/formulas/SimpleConjunction.cpp
@@ -1,0 +1,37 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#include <knowrob/formulas/SimpleConjunction.h>
+#include "knowrob/formulas/Negation.h"
+#include "knowrob/integration/python/utils.h"
+
+using namespace knowrob;
+
+std::vector<FormulaPtr> literalsToFormulae(const std::vector<FirstOrderLiteral> &literals) {
+	std::vector<FormulaPtr> formulae;
+	for (const auto &literal: literals) {
+		if(literal.isNegated()) {
+			formulae.push_back(std::make_shared<Negation>(literal.predicate()));
+		} else {
+			formulae.push_back(literal.predicate());
+		}
+	}
+	return formulae;
+}
+
+SimpleConjunction::SimpleConjunction(const std::vector<FirstOrderLiteral> &literals)
+		: Conjunction(literalsToFormulae(literals)), literals_(literals) {
+}
+
+namespace knowrob::py {
+	template<>
+	void createType<SimpleConjunction>() {
+		using namespace boost::python;
+		class_<SimpleConjunction, std::shared_ptr<SimpleConjunction>, bases<Conjunction>>
+				("SimpleConjunction", init<const std::vector<FirstOrderLiteral> &>()).
+				def("literals", &SimpleConjunction::literals, return_value_policy<copy_const_reference>());
+	}
+}
+

--- a/src/formulas/SimpleConjunction.cpp
+++ b/src/formulas/SimpleConjunction.cpp
@@ -9,20 +9,24 @@
 
 using namespace knowrob;
 
-std::vector<FormulaPtr> literalsToFormulae(const std::vector<FirstOrderLiteral> &literals) {
+std::vector<FormulaPtr> literalsToFormulae(const std::vector<FirstOrderLiteralPtr> &literals) {
 	std::vector<FormulaPtr> formulae;
 	for (const auto &literal: literals) {
-		if(literal.isNegated()) {
-			formulae.push_back(std::make_shared<Negation>(literal.predicate()));
+		if (literal->isNegated()) {
+			formulae.push_back(std::make_shared<Negation>(literal->predicate()));
 		} else {
-			formulae.push_back(literal.predicate());
+			formulae.push_back(literal->predicate());
 		}
 	}
 	return formulae;
 }
 
-SimpleConjunction::SimpleConjunction(const std::vector<FirstOrderLiteral> &literals)
+SimpleConjunction::SimpleConjunction(const std::vector<FirstOrderLiteralPtr> &literals)
 		: Conjunction(literalsToFormulae(literals)), literals_(literals) {
+}
+
+SimpleConjunction::SimpleConjunction(const FirstOrderLiteralPtr &literal)
+		: SimpleConjunction(std::vector<FirstOrderLiteralPtr>{literal}) {
 }
 
 namespace knowrob::py {
@@ -30,7 +34,7 @@ namespace knowrob::py {
 	void createType<SimpleConjunction>() {
 		using namespace boost::python;
 		class_<SimpleConjunction, std::shared_ptr<SimpleConjunction>, bases<Conjunction>>
-				("SimpleConjunction", init<const std::vector<FirstOrderLiteral> &>()).
+				("SimpleConjunction", init<const std::vector<FirstOrderLiteralPtr> &>()).
 				def("literals", &SimpleConjunction::literals, return_value_policy<copy_const_reference>());
 	}
 }

--- a/src/integration/prolog/PrologTerm.cpp
+++ b/src/integration/prolog/PrologTerm.cpp
@@ -656,16 +656,17 @@ bool PrologTerm::putCompound(CompoundFormula *phi, term_t pl_term, const functor
 		int counter = 1;
 		term_t last_head = PL_new_term_ref();
 
-		for (auto i = phi->formulae().size() - 1; i >= 0; --i) {
+		for (auto i = phi->formulae().size(); i > 0; --i) {
+			auto j = i - 1;
 			if (counter == 1) {
 				// create term for last formula, remember in last_head term
-				if (!putFormula(phi->formulae()[i], last_head)) return false;
+				if (!putFormula(phi->formulae()[j], last_head)) return false;
 			} else {
 				// create a 2-ary predicate using last_head as second argument
 				term_t pl_arg = PL_new_term_refs(2);
-				if (!putFormula(phi->formulae()[i], pl_arg) ||
+				if (!putFormula(phi->formulae()[j], pl_arg) ||
 					!PL_put_term(pl_arg + 1, last_head) ||
-					!PL_cons_functor_v((i == 0 ? pl_term : last_head), pl_functor, pl_arg)) {
+					!PL_cons_functor_v((j == 0 ? pl_term : last_head), pl_functor, pl_arg)) {
 					return false;
 				}
 

--- a/src/reasoner/GoalDrivenReasoner.cpp
+++ b/src/reasoner/GoalDrivenReasoner.cpp
@@ -8,6 +8,14 @@
 
 using namespace knowrob;
 
+bool GoalDrivenReasoner::hasFeature(GoalDrivenReasonerFeature feature) const {
+	return (features_ & static_cast<int>(feature)) != 0;
+}
+
+void GoalDrivenReasoner::enableFeature(GoalDrivenReasonerFeature feature) {
+	features_ = features_ | static_cast<int>(feature);
+}
+
 void ReasonerRunner::run() {
 	if (!reasoner->evaluateQuery(query)) {
 		KB_WARN("Reasoner {} produced 'false' in query evaluation for query: {}",
@@ -40,14 +48,23 @@ namespace knowrob::py {
 	template<>
 	void createType<GoalDrivenReasoner>() {
 		using namespace boost::python;
+
+		// export the GoalDrivenReasonerFeature enum
+		enum_<GoalDrivenReasonerFeature>("GoalDrivenReasonerFeature")
+				.value("SupportsSimpleConjunctions", GoalDrivenReasonerFeature::SupportsSimpleConjunctions);
+
+		// export the GoalDrivenReasoner class
 		class_<GoalDrivenReasoner, std::shared_ptr<GoalDrivenReasonerWrap>, bases<Reasoner>, boost::noncopyable>
 				("GoalDrivenReasoner", init<>())
+				.def("hasFeature", &GoalDrivenReasoner::hasFeature)
+				.def("enableFeature", &GoalDrivenReasoner::enableFeature)
 				.def("isRelationDefined", &GoalDrivenReasoner::isRelationDefined)
 				.def("defineRelation", &GoalDrivenReasoner::defineRelation)
 				.def("unDefineRelation", &GoalDrivenReasoner::unDefineRelation)
 						// methods that must be implemented by reasoner plugins
 				.def("evaluateQuery", &GoalDrivenReasonerWrap::evaluateQuery);
 
+		// export sub-types
 		createType<ReasonerQuery>();
 	}
 }

--- a/src/reasoner/GoalDrivenReasoner.cpp
+++ b/src/reasoner/GoalDrivenReasoner.cpp
@@ -19,7 +19,7 @@ void GoalDrivenReasoner::enableFeature(GoalDrivenReasonerFeature feature) {
 void ReasonerRunner::run() {
 	if (!reasoner->evaluateQuery(query)) {
 		KB_WARN("Reasoner {} produced 'false' in query evaluation for query: {}",
-				 *reasoner->reasonerName(), *query->literal());
+				*reasoner->reasonerName(), *query->formula());
 	}
 	query->finish();
 }

--- a/src/reasoner/ReasonerManager.cpp
+++ b/src/reasoner/ReasonerManager.cpp
@@ -140,7 +140,7 @@ void ReasonerManager::initPlugin(const std::shared_ptr<NamedReasoner> &namedReas
 
 TokenBufferPtr ReasonerManager::evaluateQuery(
 		const GoalDrivenReasonerPtr &reasoner,
-		const FramedTriplePatternPtr &literal,
+		const FirstOrderLiteralPtr &literal,
 		const QueryContextPtr &ctx) {
 	auto reasonerRunner = std::make_shared<ReasonerRunner>();
 	reasonerRunner->reasoner = reasoner;
@@ -150,7 +150,7 @@ TokenBufferPtr ReasonerManager::evaluateQuery(
 			reasonerRunner,
 			[reasonerRunner](const std::exception &exc) {
 				KB_ERROR("Reasoner {} produced an error in query evaluation: {} [{}]",
-						 *reasonerRunner->reasoner->reasonerName(), exc.what(), *reasonerRunner->query->literal());
+						 *reasonerRunner->reasoner->reasonerName(), exc.what(), *reasonerRunner->query->formula());
 			});
 	// return the (incomplete) answer buffer
 	return reasonerRunner->query->answerBuffer();

--- a/src/reasoner/ReasonerQuery.cpp
+++ b/src/reasoner/ReasonerQuery.cpp
@@ -8,9 +8,16 @@
 
 using namespace knowrob;
 
-ReasonerQuery::ReasonerQuery(FramedTriplePatternPtr literal, QueryContextPtr ctx)
+ReasonerQuery::ReasonerQuery(SimpleConjunctionPtr formula, QueryContextPtr ctx)
 		: Query(ctx),
-		  literal_(std::move(literal)),
+		  formula_(std::move(formula)),
+		  ctx_(std::move(ctx)),
+		  answerBuffer_(std::make_shared<TokenBuffer>()),
+		  outputChannel_(TokenStream::Channel::create(answerBuffer_)) {}
+
+ReasonerQuery::ReasonerQuery(const FirstOrderLiteralPtr &literal, QueryContextPtr ctx)
+		: Query(ctx),
+		  formula_(std::make_shared<SimpleConjunction>(literal)),
 		  ctx_(std::move(ctx)),
 		  answerBuffer_(std::make_shared<TokenBuffer>()),
 		  outputChannel_(TokenStream::Channel::create(answerBuffer_)) {}
@@ -26,7 +33,7 @@ namespace knowrob::py {
 
 		class_<ReasonerQuery, std::shared_ptr<ReasonerQuery>, boost::noncopyable>
 				("ReasonerQuery", init<FramedTriplePatternPtr, QueryContextPtr>())
-				.def("literal", &ReasonerQuery::literal, return_value_policy<copy_const_reference>())
+				.def("formula", &ReasonerQuery::formula, return_value_policy<copy_const_reference>())
 				.def("answerBuffer", &ReasonerQuery::answerBuffer, return_value_policy<copy_const_reference>())
 				.def("ctx", &Query::ctx, return_value_policy<copy_const_reference>())
 				.def("push", &ReasonerQuery::push);


### PR DESCRIPTION
- A new type `SimpleConjunction` (a conjunction of literals) is introduced
- The `ReasonerQuery` type accepted by `GoalDrivenReasoner` was changed to use `SimpleConjunction` instead of a single literal
- A testcase is added for PrologReasoner that tests if `SimpleConjunction` can be handled through the `evaluateQuery` interface
- I encountered a bug with unsigned type which is also fixed by this PR

Note that the `SupportsSimpleConjunctions` feature is currently ignored by the knowledge base. A consecutive PR could address this and make use of the feature flag in query pipeline construction.