### PR TITLE
Fix python kernel crash in Jupyter Notebooks

### DIFF
--- a/src/knowrob.cpp
+++ b/src/knowrob.cpp
@@ -72,8 +72,11 @@ namespace knowrob {
 		Logger::initialize();
 		// Allow Python to load modules KnowRob-related directories.
 		InitPythonPath();
-		// start a Python interpreter
-		Py_Initialize();
+		// Check if Python is already initialized
+		if (!Py_IsInitialized()) {
+        	// Start a Python interpreter if it is not already initialized
+			Py_Initialize();
+		}
 		KB_INFO("[KnowRob] static initialization done.");
 		KB_DEBUG("[KnowRob] source directory: {}", KNOWROB_SOURCE_DIR);
 		KB_DEBUG("[KnowRob] install prefix: {}", KNOWROB_INSTALL_PREFIX);


### PR DESCRIPTION
In Jupyter Notebooks we regularly get this error:

Fatal Python error: PyThreadState_Get: the function must be called with the GIL held, but the GIL is released (the current Python thread state is NULL)

This seems a threading issue, in the init function of Knowrob we call Py_Initialize, which could be a problem because a python interpreter is created inside of a running python interpreter. To fix this I sourround the call with Py_Initialized. 

This seems to fix the issue.