### PR TITLE
Use weak self pointer in KnowledgeBase class

### DIFF
--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -25,23 +25,25 @@ namespace knowrob {
 	 * its 'tell' and 'ask' interface.
 	 */
 	class KnowledgeBase : public std::enable_shared_from_this<KnowledgeBase> {
-		struct Private{ explicit Private() = default; };
-
 	public:
 		/**
+		 * Create a new KnowledgeBase instance.
+		 * Note that it is perfectly fine to have multiple KnowledgeBase instances in one application.
 		 * @param config a property tree used to configure this.
 		 */
-		KnowledgeBase(Private, const boost::property_tree::ptree &config);
+		static std::shared_ptr<KnowledgeBase> create(const boost::property_tree::ptree &config);
 
 		/**
+		 * Create a new KnowledgeBase instance.
+		 * Note that it is perfectly fine to have multiple KnowledgeBase instances in one application.
 		 * @param config a JSON string used to configure this or the path to a JSON file.
 		 */
-		KnowledgeBase(Private, std::string_view config);
-
-		explicit KnowledgeBase(Private);
-
-		static std::shared_ptr<KnowledgeBase> create(const boost::property_tree::ptree &config);
 		static std::shared_ptr<KnowledgeBase> create(std::string_view config);
+
+		/**
+		 * Create a new KnowledgeBase instance.
+		 * Note that it is perfectly fine to have multiple KnowledgeBase instances in one application.
+		 */
 		static std::shared_ptr<KnowledgeBase> create();
 
 		~KnowledgeBase();
@@ -157,6 +159,12 @@ namespace knowrob {
 		std::shared_ptr<StorageManager> backendManager_;
 		std::shared_ptr<Vocabulary> vocabulary_;
 		bool isInitialized_;
+
+		KnowledgeBase(const boost::property_tree::ptree &config);
+
+		KnowledgeBase(std::string_view config);
+
+		explicit KnowledgeBase();
 
 		void configure(const boost::property_tree::ptree &config);
 

--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -24,19 +24,25 @@ namespace knowrob {
 	 * The main interface to the knowledge base system implementing
 	 * its 'tell' and 'ask' interface.
 	 */
-	class KnowledgeBase {
+	class KnowledgeBase : public std::enable_shared_from_this<KnowledgeBase> {
+		struct Private{ explicit Private() = default; };
+
 	public:
 		/**
 		 * @param config a property tree used to configure this.
 		 */
-		explicit KnowledgeBase(const boost::property_tree::ptree &config);
+		KnowledgeBase(Private, const boost::property_tree::ptree &config);
 
 		/**
 		 * @param config a JSON string used to configure this or the path to a JSON file.
 		 */
-		explicit KnowledgeBase(std::string_view config);
+		KnowledgeBase(Private, std::string_view config);
 
-		KnowledgeBase();
+		explicit KnowledgeBase(Private);
+
+		static std::shared_ptr<KnowledgeBase> create(const boost::property_tree::ptree &config);
+		static std::shared_ptr<KnowledgeBase> create(std::string_view config);
+		static std::shared_ptr<KnowledgeBase> create();
 
 		~KnowledgeBase();
 

--- a/include/knowrob/integration/InterfaceUtils.h
+++ b/include/knowrob/integration/InterfaceUtils.h
@@ -32,7 +32,7 @@ namespace knowrob {
 		 * @param args the statements.
 		 * @return true if all statements are true.
 		 */
-		static bool assertStatements(KnowledgeBase &kb_, const std::vector<FormulaPtr> &args);
+		static bool assertStatements(const KnowledgeBasePtr &kb_, const std::vector<FormulaPtr> &args);
 
 		/**
 		 * Apply a modality to a formula.

--- a/include/knowrob/integration/ros1/ROSInterface.h
+++ b/include/knowrob/integration/ros1/ROSInterface.h
@@ -48,7 +48,7 @@ namespace knowrob {
 		ros::ServiceServer ask_incremental_finish_service_;
 
 		// KnowledgeBase
-		KnowledgeBase kb_;
+		KnowledgeBasePtr kb_;
 
 		// Mutex to protect query_results_
 		std::mutex query_mutex_;

--- a/include/knowrob/queries/ModalStage.h
+++ b/include/knowrob/queries/ModalStage.h
@@ -16,12 +16,12 @@ namespace knowrob {
 	 */
 	class ModalStage : public TypedQueryStage<Formula> {
 	public:
-		ModalStage(KnowledgeBase *kb,
+		ModalStage(const std::shared_ptr<KnowledgeBase> &kb,
 				   const std::shared_ptr<ModalFormula> &modal,
 				   const QueryContextPtr &ctx);
 
 	protected:
-		KnowledgeBase *kb_;
+		std::shared_ptr<KnowledgeBase> kb_;
 		std::shared_ptr<ModalFormula> modalFormula_;
 		QueryContextPtr nestedContext_;
 

--- a/include/knowrob/queries/NegationStage.h
+++ b/include/knowrob/queries/NegationStage.h
@@ -19,10 +19,10 @@ namespace knowrob {
 	 */
 	class NegationStage : public TokenBroadcaster {
 	public:
-		NegationStage(KnowledgeBase *kb, QueryContextPtr ctx);
+		NegationStage(const std::shared_ptr<KnowledgeBase> &kb, QueryContextPtr ctx);
 
 	protected:
-		KnowledgeBase *kb_;
+		std::shared_ptr<KnowledgeBase> kb_;
 		const QueryContextPtr ctx_;
 
 		void pushToBroadcast(const TokenPtr &tok) override;
@@ -32,7 +32,7 @@ namespace knowrob {
 
 	class PredicateNegationStage : public NegationStage {
 	public:
-		PredicateNegationStage(KnowledgeBase *kb,
+		PredicateNegationStage(const std::shared_ptr<KnowledgeBase> &kb,
 							   const QueryContextPtr &ctx,
 							   const std::vector<FramedTriplePatternPtr> &negatedLiterals);
 
@@ -44,7 +44,7 @@ namespace knowrob {
 
 	class ModalNegationStage : public NegationStage {
 	public:
-		ModalNegationStage(KnowledgeBase *kb,
+		ModalNegationStage(const std::shared_ptr<KnowledgeBase> &kb,
 						   const QueryContextPtr &ctx,
 						   const std::vector<std::shared_ptr<ModalFormula>> &negatedModals);
 

--- a/include/knowrob/queries/QueryPipeline.h
+++ b/include/knowrob/queries/QueryPipeline.h
@@ -29,14 +29,14 @@ namespace knowrob {
 		 * @param phi the formula to query.
 		 * @param ctx the query context.
 		 */
-		QueryPipeline(KnowledgeBase *kb, const FormulaPtr &phi, const QueryContextPtr &ctx);
+		QueryPipeline(const std::shared_ptr<KnowledgeBase> &kb, const FormulaPtr &phi, const QueryContextPtr &ctx);
 
 		/**
 		 * Create a query pipeline for the given graph query.
 		 * @param kb the knowledge base to query.
 		 * @param graphQuery the graph query to execute.
 		 */
-		QueryPipeline(KnowledgeBase *kb, const GraphPathQueryPtr &graphQuery);
+		QueryPipeline(const std::shared_ptr<KnowledgeBase> &kb, const GraphPathQueryPtr &graphQuery);
 
 		~QueryPipeline();
 
@@ -59,11 +59,11 @@ namespace knowrob {
 		void addStage(const std::shared_ptr<TokenStream> &stage);
 
 		static std::vector<RDFComputablePtr> createComputationSequence(
-				KnowledgeBase *kb,
+				const std::shared_ptr<KnowledgeBase> &kb,
 				const std::list<DependencyNodePtr> &dependencyGroup);
 
 		void createComputationPipeline(
-				KnowledgeBase *kb,
+				const std::shared_ptr<KnowledgeBase> &kb,
 				const std::vector<RDFComputablePtr> &computableLiterals,
 				const std::shared_ptr<TokenBroadcaster> &pipelineInput,
 				const std::shared_ptr<TokenBroadcaster> &pipelineOutput,

--- a/include/knowrob/reasoner/prolog/PrologTests.h
+++ b/include/knowrob/reasoner/prolog/PrologTests.h
@@ -70,7 +70,7 @@ namespace knowrob {
 				ss << "prolog_";
 				insertUnique(ss);
 
-				kb = std::make_shared<KnowledgeBase>();
+				kb = KnowledgeBase::create();
 				db = createBackend(ss.str(), kb);
 				reasoner = createReasoner(ss.str(), kb, db);
 

--- a/src/integration/InterfaceUtils.cpp
+++ b/src/integration/InterfaceUtils.cpp
@@ -49,7 +49,7 @@ boost::property_tree::ptree InterfaceUtils::loadSettings() {
 
 }
 
-bool InterfaceUtils::assertStatements(KnowledgeBase &kb_, const std::vector<FormulaPtr> &args) {
+bool InterfaceUtils::assertStatements(const KnowledgeBasePtr &kb_, const std::vector<FormulaPtr> &args) {
 	std::vector<FramedTriplePtr> data(args.size());
 	std::vector<FramedTriplePatternPtr> buf(args.size());
 	uint32_t dataIndex = 0;
@@ -77,7 +77,7 @@ bool InterfaceUtils::assertStatements(KnowledgeBase &kb_, const std::vector<Form
 			}
 		}
 	}
-	if (kb_.insertAll(data)) {
+	if (kb_->insertAll(data)) {
 		std::cout << "success, " << dataIndex << " statement(s) were asserted." << "\n";
 		return true;
 	} else {

--- a/src/integration/ros1/ROSInterface.cpp
+++ b/src/integration/ros1/ROSInterface.cpp
@@ -39,7 +39,7 @@ ROSInterface::ROSInterface(const boost::property_tree::ptree &config)
 													  boost::bind(&ROSInterface::executeAskIncrementalNextSolutionCB,
 																  this, _1), false),
 		  tell_action_server_(nh_, "knowrob/tell", boost::bind(&ROSInterface::executeTellCB, this, _1), false),
-		  kb_(config) {
+		  kb_(KnowledgeBase::create(config)) {
 	// Start all action servers
 	askall_action_server_.start();
 	askone_action_server_.start();
@@ -135,7 +135,7 @@ void ROSInterface::executeAskAllCB(const AskAllGoalConstPtr &goal) {
 	FormulaPtr mPhi = InterfaceUtils::applyModality(translateGraphQueryMessage(goal->query), phi);
 
 	auto ctx = std::make_shared<QueryContext>(QUERY_FLAG_ALL_SOLUTIONS);
-	auto resultStream = kb_.submitQuery(mPhi, ctx);
+	auto resultStream = kb_->submitQuery(mPhi, ctx);
 	auto resultQueue = resultStream->createQueue();
 
 	int numSolutions_ = 0;
@@ -183,7 +183,7 @@ void ROSInterface::executeAskIncrementalCB(const AskIncrementalGoalConstPtr &goa
 	FormulaPtr mPhi = InterfaceUtils::applyModality(translateGraphQueryMessage(goal->query), phi);
 
 	auto ctx = std::make_shared<QueryContext>(QUERY_FLAG_ALL_SOLUTIONS);
-	auto resultStream = kb_.submitQuery(mPhi, ctx);
+	auto resultStream = kb_->submitQuery(mPhi, ctx);
 	auto resultQueue = resultStream->createQueue();
 
 	// Store result queue for execution of next solution
@@ -279,7 +279,7 @@ void ROSInterface::executeAskOneCB(const AskOneGoalConstPtr &goal) {
 	FormulaPtr mPhi = InterfaceUtils::applyModality(translateGraphQueryMessage(goal->query), phi);
 
 	auto ctx = std::make_shared<QueryContext>(QUERY_FLAG_ALL_SOLUTIONS);
-	auto resultStream = kb_.submitQuery(mPhi, ctx);
+	auto resultStream = kb_->submitQuery(mPhi, ctx);
 	auto resultQueue = resultStream->createQueue();
 
 	AskOneResult result;

--- a/src/queries/ModalStage.cpp
+++ b/src/queries/ModalStage.cpp
@@ -12,7 +12,7 @@
 using namespace knowrob;
 
 ModalStage::ModalStage(
-		KnowledgeBase *kb,
+		const std::shared_ptr<KnowledgeBase> &kb,
 		const std::shared_ptr<ModalFormula> &modal,
 		const QueryContextPtr &ctx)
 		: TypedQueryStage(ctx, modal->modalFormula(),

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -12,7 +12,7 @@
 
 using namespace knowrob;
 
-NegationStage::NegationStage(KnowledgeBase *kb, QueryContextPtr ctx)
+NegationStage::NegationStage(const std::shared_ptr<KnowledgeBase> &kb, QueryContextPtr ctx)
 		: TokenBroadcaster(),
 		  kb_(kb),
 		  ctx_(std::move(ctx)) {}
@@ -29,7 +29,7 @@ void NegationStage::pushToBroadcast(const TokenPtr &tok) {
 	TokenBroadcaster::pushToBroadcast(tok);
 }
 
-PredicateNegationStage::PredicateNegationStage(KnowledgeBase *kb,
+PredicateNegationStage::PredicateNegationStage(const std::shared_ptr<KnowledgeBase> &kb,
 											   const QueryContextPtr &ctx,
 											   const std::vector<FramedTriplePatternPtr> &negatedLiterals)
 		: NegationStage(kb, ctx),
@@ -89,7 +89,7 @@ bool PredicateNegationStage::succeeds(const AnswerYesPtr &answer) {
 	return true;
 }
 
-ModalNegationStage::ModalNegationStage(KnowledgeBase *kb,
+ModalNegationStage::ModalNegationStage(const std::shared_ptr<KnowledgeBase> &kb,
 									   const QueryContextPtr &ctx,
 									   const std::vector<std::shared_ptr<ModalFormula>> &negatedModals)
 		: NegationStage(kb, ctx),

--- a/src/reasoner/mongolog/MongologReasoner.cpp
+++ b/src/reasoner/mongolog/MongologReasoner.cpp
@@ -283,7 +283,7 @@ namespace knowrob::testing {
 				ss << "mongolog_";
 				insertUnique(ss);
 
-				kb = std::make_shared<KnowledgeBase>();
+				kb = KnowledgeBase::create();
 				db = createBackend2(ss.str(), kb);
 				reasoner = createReasoner2(ss.str(), kb, db);
 

--- a/src/reasoner/prolog/PrologReasoner.cpp
+++ b/src/reasoner/prolog/PrologReasoner.cpp
@@ -282,10 +282,9 @@ AnswerNoPtr PrologReasoner::no(const ReasonerQueryPtr &query) {
 	negativeAnswer->setIsUncertain(true, std::nullopt);
 
 	// add literals to the answer for which the query has failed.
-	// TODO: [PrologReasoner] Add a mechanism to determine which literal fails in a
-	//       complex query, i.e. involving conjunctions or disjunctions.
-	//       Currently the failing literals can only be reported in simple queries
-	//       involving only a single literal.
+	// NOTE: At the moment negations will only appear in simple queries
+	//       without connective operators, so no problem that below we can
+	//       only handle queries with a single literal.
 	auto &literals = query->formula()->literals();
 	if (literals.size() == 1) {
 		auto &firstLiteral = *literals.begin();

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -149,7 +149,7 @@ public:
 			: has_stop_request_(false),
 			  cursor_(0),
 			  numSolutions_(0),
-			  kb_(config),
+			  kb_(KnowledgeBase::create(config)),
 			  historyFile_("history.txt") {
 		try {
 			history_.load(historyFile_);
@@ -266,7 +266,7 @@ public:
 
 	void runQuery(const std::shared_ptr<const FormulaQuery> &query) {
 		// evaluate query in hybrid QA system
-		auto resultStream = kb_.submitQuery(query->formula(), query->ctx());
+		auto resultStream = kb_->submitQuery(query->formula(), query->ctx());
 		auto resultQueue = resultStream->createQueue();
 
 		numSolutions_ = 0;
@@ -416,8 +416,8 @@ public:
 		auto uri = PrefixRegistry::aliasToUri(nsAlias);
 		if (uri.has_value()) {
 			auto partialIRI = uri.value().get() + "#" + word;
-			auto propertyOptions = kb_.vocabulary()->getDefinedPropertyNamesWithPrefix(partialIRI);
-			auto classOptions = kb_.vocabulary()->getDefinedClassNamesWithPrefix(partialIRI);
+			auto propertyOptions = kb_->vocabulary()->getDefinedPropertyNamesWithPrefix(partialIRI);
+			auto classOptions = kb_->vocabulary()->getDefinedClassNamesWithPrefix(partialIRI);
 			size_t namePosition = uri.value().get().length() + 1;
 
 			// create options array holding only the name of entities.
@@ -594,7 +594,7 @@ public:
 	}
 
 protected:
-	KnowledgeBase kb_;
+	KnowledgeBasePtr kb_;
 	std::atomic<bool> has_stop_request_;
 	int numSolutions_;
 	uint32_t cursor_;

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -91,7 +91,7 @@ public:
 
 void KnowledgeBaseTest::SetUpTestSuite() {
 	// initialize a KB, setup database backend for testing, insert tmp data on which queries can be evaluated
-	kb_ = std::make_shared<KnowledgeBase>(KB_TEST_SETTINGS_FILE);
+	kb_ = KnowledgeBase::create(KB_TEST_SETTINGS_FILE);
 
 	Fred_   = IRIAtom::Tabled(QueryParser::parseRawAtom("swrl_test:Fred"));
 	Ernest_ = IRIAtom::Tabled(QueryParser::parseRawAtom("swrl_test:Ernest"));


### PR DESCRIPTION
Currently, stages in a query pipeline must be able to submit sub-queries to the knowledge base. e.g. in case of nested formula wrapped in a modal operator.

This PR changes the way how stages hold a reference on the KB. Before the PR it was not safe as stages only held a pointer to the KB. Now the stages hold a proper reference to the KB which ensures the KB is not being destructor as long as the stages are still active.

This PR changes the way how KnowledgeBase objects must be constructed on the C++ side. Python-side is not affected, it is still possible to use regular Python constructors e.g. `KnowledgeBase()` is still valid in Python but not in C++