### PR TITLE
Manage the GIL of Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,8 @@ add_library(knowrob SHARED
         src/reasoner/ReasonerEvent.cpp
         src/ontologies/TransformedOntology.cpp
         src/reasoner/ReasonerQuery.cpp
-        src/formulas/SimpleConjunction.cpp)
+        src/formulas/SimpleConjunction.cpp
+        src/integration/python/converter/shared_ptr.cpp)
 set(KNOWROB_LIBRARIES
         ${SWIPL_LIBRARIES}
         ${MONGOC_LIBRARIES}

--- a/include/knowrob/integration/python/converter/shared_ptr.h
+++ b/include/knowrob/integration/python/converter/shared_ptr.h
@@ -7,27 +7,5 @@
 #define KNOWROB_PY_CONVERTER_SHARED_PTR_H
 
 #include <boost/python.hpp>
-#include <memory>
-#include <knowrob/integration/python/gil.h>
-
-namespace boost::python::converter {
-	void shared_ptr_deleter::operator()(void const *) {
-		// This is needed to release the Python GIL when the shared_ptr is deleted.
-		// Otherwise, if the shared_ptr is deleted in a C++ thread,
-		// Python will crash because the GIL is not acquired.
-		// There was also a debate about adding this to boost which was not really conclusive
-		// ite seems.
-		// @see https://github.com/boostorg/python/pull/11
-		knowrob::py::gil_lock gil;
-		owner.reset();
-	}
-}
-
-namespace boost {
-	// This is needed for boost::python to work with std::shared_ptr.
-	// @see https://stackoverflow.com/questions/46435509/boostpython-stdshared-ptr-to-stdshared-ptr
-	template<class T>
-	T *get_pointer(std::shared_ptr<T> p) { return p.get(); }
-}
 
 #endif //KNOWROB_PY_CONVERTER_SHARED_PTR_H

--- a/include/knowrob/integration/python/utils.h
+++ b/include/knowrob/integration/python/utils.h
@@ -9,6 +9,7 @@
 #include <boost/python.hpp>
 #include <filesystem>
 #include "PythonError.h"
+#include "gil.h"
 
 namespace knowrob::py {
 	// call a method of a python object
@@ -30,6 +31,15 @@ namespace knowrob::py {
 		} catch(const boost::python::error_already_set&) {
 			throw PythonError();
 		}
+	}
+
+	/**
+	 * Same as call but locks the GIL before performing the call.
+	 * @param goal the function to call.
+	 */
+	template<typename R> R call_with_gil(const std::function<R()>& goal) {
+		py::gil_lock lock;
+		return call(goal);
 	}
 
 	/**

--- a/include/knowrob/knowrob.h
+++ b/include/knowrob/knowrob.h
@@ -19,7 +19,7 @@ namespace knowrob {
 	 * @param argc number of arguments in argv.
 	 * @param argv array of program arguments, argv[0] is the name of the binary.
 	 */
-	void InitKnowRob(int argc, char **argv);
+	void InitKnowRob(int argc, char **argv, bool initPython = true);
 
 	/**
 	 * Shutdown the knowledge base.

--- a/include/knowrob/plugins/PluginModule.h
+++ b/include/knowrob/plugins/PluginModule.h
@@ -41,7 +41,7 @@ namespace knowrob {
 		 * @return true if the module was loaded successfully.
 		 */
 		bool isLoaded() {
-			return knowrob::py::call<bool>([&] {
+			return knowrob::py::call_with_gil<bool>([&] {
 				return pyPluginType_ && !pyPluginType_.is_none();
 			});
 		}

--- a/src/integration/python/converter/shared_ptr.cpp
+++ b/src/integration/python/converter/shared_ptr.cpp
@@ -1,0 +1,28 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#include <knowrob/Logger.h>
+#include <knowrob/integration/python/gil.h>
+#include <knowrob/integration/python/converter/shared_ptr.h>
+
+namespace boost::python::converter {
+	void shared_ptr_deleter::operator()(void const *) {
+		// This is needed to release the Python GIL when the shared_ptr is deleted.
+		// Otherwise, if the shared_ptr is deleted in a C++ thread,
+		// Python will crash because the GIL is not acquired.
+		// There was also a debate about adding this to boost which was not really conclusive
+		// ite seems.
+		// @see https://github.com/boostorg/python/pull/11
+		knowrob::py::gil_lock gil;
+		owner.reset();
+	}
+}
+
+namespace boost {
+	// This is needed for boost::python to work with std::shared_ptr.
+	// @see https://stackoverflow.com/questions/46435509/boostpython-stdshared-ptr-to-stdshared-ptr
+	template<class T>
+	T *get_pointer(std::shared_ptr<T> p) { return p.get(); }
+}

--- a/src/knowrob.cpp
+++ b/src/knowrob.cpp
@@ -73,12 +73,14 @@ namespace knowrob {
 		// Allow Python to load modules KnowRob-related directories.
 		InitPythonPath();
 		if (initPython) {
-			// Check if Python is already initialized
-			if (!Py_IsInitialized()) {
-				// Start a Python interpreter if it is not already initialized
-				Py_Initialize();
-			}
-			// FIXME: foo bar baz
+			// Start a Python interpreter if it is not already initialized
+			Py_Initialize();
+			// Release the GIL which is acquired by Py_Initialize.
+			// If we do not release it, then no other thread would be able
+			// to run Python code.
+			// So instead we always need to acquire the GIL in C++ code sections
+			// that interact with Python (except of when the C++ code is launched
+			// within Python in which case it actually already has the GIL).
 			PyEval_SaveThread();
 		}
 		KB_INFO("[KnowRob] static initialization done.");

--- a/tests/py/test-jupyter.cpp
+++ b/tests/py/test-jupyter.cpp
@@ -37,7 +37,7 @@ protected:
 	// Per-test-suite set-up.
 	static void SetUpTestSuite() {
 		try {
-			py::call<void>([&] {
+			py::call_with_gil<void>([&] {
 				// make sure the knowrob module is loaded, without it conversion of types won't work.
 				// Conditionally import module based on MODULENAME
 				if (std::string(moduleNameStr()) == "knowrob") {
@@ -90,7 +90,8 @@ python::object JupyterTests::knowrob_module;
 #define BOOST_TEST_CALL0(method_name, ...) call(__FILE__, __LINE__, method_name, __VA_ARGS__)
 #define BOOST_TEST_CALL1(method_name) call(__FILE__, __LINE__, method_name)
 
-#define TEST_JUPYTER(notebook) \
-	EXPECT_NO_THROW(BOOST_TEST_CALL0("test_notebook", python::object(URI::resolve(notebook))))
+#define TEST_JUPYTER(notebook) {  \
+    py::gil_lock lock;            \
+    EXPECT_NO_THROW(BOOST_TEST_CALL0("test_notebook", python::object(URI::resolve(notebook)))); }
 
 TEST_F(JupyterTests, python_kb) { TEST_JUPYTER("jupyter/python-kb.ipynb"); }

--- a/tests/py/test-module.cpp
+++ b/tests/py/test-module.cpp
@@ -26,11 +26,20 @@ protected:
 	static python::object test_module;
 	static python::object knowrob_module;
 	static python::object AssertionError;
+	PyGILState_STATE gilState;
 
 
 	// Function to return the module name as a string
 	static constexpr const char *moduleNameStr() {
 		return TOSTRING(MODULENAME);
+	}
+
+	void SetUp() override {
+		gilState = PyGILState_Ensure();
+	}
+
+	void TearDown() override {
+		PyGILState_Release(gilState);
 	}
 
 	// Per-test-suite set-up.
@@ -55,8 +64,6 @@ protected:
 	}
 
 	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name, const std::function<python::object(python::object &)> &gn) {
-		py::gil_lock lock;
-
 		EXPECT_FALSE(test_module.is_none());
 		if (test_module.is_none()) { return {}; }
 

--- a/tests/py/test-module.cpp
+++ b/tests/py/test-module.cpp
@@ -36,7 +36,7 @@ protected:
 	// Per-test-suite set-up.
 	static void SetUpTestSuite() {
 		try {
-			py::call<void>([&] {
+			py::call_with_gil<void>([&] {
 				// make sure the knowrob module is loaded, without it conversion of types won't work.
 				// Conditionally import module based on MODULENAME
 				if (std::string(moduleNameStr()) == "knowrob") {
@@ -55,6 +55,8 @@ protected:
 	}
 
 	static python::object do_call(std::string_view file, uint32_t line, std::string_view method_name, const std::function<python::object(python::object &)> &gn) {
+		py::gil_lock lock;
+
 		EXPECT_FALSE(test_module.is_none());
 		if (test_module.is_none()) { return {}; }
 
@@ -87,7 +89,7 @@ python::object BoostPythonTests::test_module;
 python::object BoostPythonTests::knowrob_module;
 
 #define EXPECT_CONVERTIBLE_TO_PY(x) EXPECT_NO_THROW( EXPECT_FALSE( \
-	py::call<bool>([&]{ return boost::python::object(x).is_none(); })))
+	py::call_with_gil<bool>([&]{ return boost::python::object(x).is_none(); })))
 #define BOOST_TEST_CALL0(method_name, ...) call(__FILE__, __LINE__, method_name, __VA_ARGS__)
 #define BOOST_TEST_CALL1(method_name) call(__FILE__, __LINE__, method_name)
 


### PR DESCRIPTION
There were a few race conditions involved with Python GIL, I hope these are fixed now.

Especially there was a race condition causing deadlocks in the deleter of shared_ptr which this PR avoids by resetting the pointer handles in a worker thread where each deletion can be queued.

One more thing this PR adds is the ability for ThreadPool to detach worker threads on exit that are deadlocked or otherwise refuse to exit, thus allowing KnowRob to make a clean exit even though there are deadlocked threads