### PR TITLE
Work on multi-threading support

### DIFF
--- a/include/knowrob/integration/python/converter/list.h
+++ b/include/knowrob/integration/python/converter/list.h
@@ -8,6 +8,7 @@
 
 #include <boost/python.hpp>
 #include <list>
+#include "knowrob/ontologies/DataSource.h"
 
 namespace knowrob::py {
 	/** handling of std::list, map to Python list. */

--- a/include/knowrob/queries/DisjunctiveBroadcaster.h
+++ b/include/knowrob/queries/DisjunctiveBroadcaster.h
@@ -22,6 +22,7 @@ namespace knowrob {
 		std::vector<AnswerNoPtr> negativeAnswers_;
 		std::vector<AnswerYesPtr> deferredPositiveAnswers_;
 		bool isCertainlyPositive_;
+		std::mutex mutex_;
 
 		// Override AnswerStream
 		void push(const TokenPtr &msg) override;

--- a/include/knowrob/queries/QueryPipeline.h
+++ b/include/knowrob/queries/QueryPipeline.h
@@ -52,11 +52,11 @@ namespace knowrob {
 		void stopBuffering();
 
 	protected:
-		std::vector<std::shared_ptr<TokenStream>> stages_;
+		std::vector<std::shared_ptr<TokenStream>> initialStages_;
 		std::shared_ptr<TokenBroadcaster> finalStage_;
 		std::shared_ptr<TokenBuffer> bufferStage_;
 
-		void addStage(const std::shared_ptr<TokenStream> &stage);
+		void addInitialStage(const std::shared_ptr<TokenStream> &stage);
 
 		static std::vector<RDFComputablePtr> createComputationSequence(
 				const std::shared_ptr<KnowledgeBase> &kb,

--- a/include/knowrob/queries/TokenBroadcaster.h
+++ b/include/knowrob/queries/TokenBroadcaster.h
@@ -18,7 +18,7 @@ namespace knowrob {
 	public:
 		TokenBroadcaster();
 
-		virtual ~TokenBroadcaster();
+		~TokenBroadcaster() override;
 
 		/**
 		 * Add a subscriber to this broadcast.
@@ -35,6 +35,7 @@ namespace knowrob {
 
 	protected:
 		std::list<std::shared_ptr<Channel>> subscribers_;
+		std::mutex mtx_;
 
 		// Override QueryResultStream
 		void push(const TokenPtr &tok) override;

--- a/include/knowrob/storage/mongo/Collection.h
+++ b/include/knowrob/storage/mongo/Collection.h
@@ -26,7 +26,7 @@ namespace knowrob::mongo {
 				std::string_view databaseName,
 				std::string_view collectionName);
 
-		Collection(const Collection &collection) = delete;
+		Collection(const Collection &collection);
 
 		~Collection();
 

--- a/src/queries/DisjunctiveBroadcaster.cpp
+++ b/src/queries/DisjunctiveBroadcaster.cpp
@@ -13,6 +13,7 @@ DisjunctiveBroadcaster::DisjunctiveBroadcaster()
 }
 
 void DisjunctiveBroadcaster::pushDeferredMessages() {
+	std::lock_guard<std::mutex> lock(mutex_);
 	if (isCertainlyPositive_) {
 		for (auto &x: deferredPositiveAnswers_) {
 			TokenBroadcaster::push(x);
@@ -49,6 +50,7 @@ void DisjunctiveBroadcaster::pushAnswer(const AnswerPtr &answer) {
 	// consider the query as satisfiable.
 
 	if (answer->isNegative()) {
+		std::lock_guard<std::mutex> lock(mutex_);
 		negativeAnswers_.emplace_back(std::static_pointer_cast<const AnswerNo>(answer));
 	} else if (answer->isPositive()) {
 		// a positive answer indicates that a subsystem suggests the input query is satisfiable.
@@ -67,6 +69,7 @@ void DisjunctiveBroadcaster::pushAnswer(const AnswerPtr &answer) {
 			TokenBroadcaster::push(answer);
 		} else {
 			// else defer pushing uncertain positive answer until a certain answer has been produced, or eof reached
+			std::lock_guard<std::mutex> lock(mutex_);
 			deferredPositiveAnswers_.emplace_back(positiveAnswer);
 		}
 	} else {

--- a/src/queries/QueryPipeline.cpp
+++ b/src/queries/QueryPipeline.cpp
@@ -452,7 +452,7 @@ void QueryPipeline::createComputationPipeline(
 			auto edbStage = std::make_shared<TypedQueryStage<FramedTriplePattern>>(
 					ctx,
 					lit,
-					[&](const FramedTriplePatternPtr &q) {
+					[kb, edb, ctx](const FramedTriplePatternPtr &q) {
 						return kb->edb()->getAnswerCursor(edb, std::make_shared<GraphPathQuery>(q, ctx));
 					});
 			edbStage->selfWeakRef_ = edbStage;
@@ -467,7 +467,7 @@ void QueryPipeline::createComputationPipeline(
 		for (auto &r: lit->reasonerList()) {
 			auto idbStage = std::make_shared<TypedQueryStage<FramedTriplePattern>>(
 					ctx, lit,
-					[&r, &ctx](const FramedTriplePatternPtr &q) {
+					[r, ctx](const FramedTriplePatternPtr &q) {
 						return ReasonerManager::evaluateQuery(r, q, ctx);
 					});
 			idbStage->selfWeakRef_ = idbStage;

--- a/src/queries/TokenStream.cpp
+++ b/src/queries/TokenStream.cpp
@@ -40,9 +40,9 @@ void TokenStream::push(Channel &channel, const TokenPtr &tok) {
 	if (tok->indicatesEndOfEvaluation()) {
 		bool doPushMsg = true;
 		if (isOpened()) {
+			// prevent channels from being created while processing EOS message
+			std::lock_guard<std::mutex> lock(channel_mutex_);
 			if (channel.hasValidIterator()) {
-				// prevent channels from being created while processing EOS message
-				std::lock_guard<std::mutex> lock(channel_mutex_);
 				// close this stream if no channels are left
 				channels_.erase(channel.iterator_);
 				channel.invalidateIterator();

--- a/src/storage/mongo/Collection.cpp
+++ b/src/storage/mongo/Collection.cpp
@@ -29,6 +29,16 @@ Collection::Collection(
 	db_ = mongoc_client_get_database(client_, dbName_.c_str());
 }
 
+Collection::Collection(const Collection &other)
+		: connection_(other.connection_),
+		  name_(other.name_),
+		  dbName_(other.dbName_),
+		  session_(nullptr) {
+	client_ = mongoc_client_pool_pop(connection_->pool_);
+	coll_ = mongoc_client_get_collection(client_, dbName_.c_str(), name_.c_str());
+	db_ = mongoc_client_get_database(client_, dbName_.c_str());
+}
+
 Collection::~Collection() {
 	if (session_) {
 		mongoc_client_session_destroy(session_);

--- a/src/storage/mongo/Cursor.cpp
+++ b/src/storage/mongo/Cursor.cpp
@@ -29,6 +29,7 @@ Cursor::Cursor(const std::shared_ptr<Collection> &collection)
 Cursor::~Cursor() {
 	if (cursor_ != nullptr) {
 		mongoc_cursor_destroy(cursor_);
+		cursor_ = nullptr;
 	}
 	bson_destroy(query_);
 	bson_destroy(opts_);
@@ -69,12 +70,12 @@ bool Cursor::next(const bson_t **doc, bool ignore_empty) {
 		if (limit_ > 0) {
 			mongoc_cursor_set_limit(cursor_, limit_);
 		}
+	}
 		// make sure cursor has no error after creation
 		bson_error_t err1;
 		if (mongoc_cursor_error(cursor_, &err1)) {
 			throw MongoException("cursor_error", err1);
 		}
-	}
 	// get next document
 	if (!mongoc_cursor_next(cursor_, doc)) {
 		// make sure cursor has no error after next has been called


### PR DESCRIPTION

- MongoKnowledgeGraph: mongo client connections cannot be shared between threads, so each active query evaluation must have its own
- avoid some race conditions in query evaluation through the use of mutex. The use might not be entirely optimal as it disables an broadcaster object to broadcast different messages at the same time -- so it might cause more waiting