### PR TITLE
Simple conjunctive queries in reasoning pipelines

### DIFF
--- a/include/knowrob/formulas/FirstOrderLiteral.h
+++ b/include/knowrob/formulas/FirstOrderLiteral.h
@@ -65,6 +65,14 @@ namespace knowrob {
 
 	using FirstOrderLiteralPtr = std::shared_ptr<FirstOrderLiteral>;
 
+	/**
+	 * Apply a substitution to a FOL literal.
+	 * @param lit the FOL literal.
+	 * @param bindings the substitution.
+	 * @return the literal with the substitution applied.
+	 */
+	FirstOrderLiteralPtr applyBindings(const FirstOrderLiteralPtr &lit, const Bindings &bindings);
+
 } // knowrob
 
 namespace std {

--- a/include/knowrob/queries/Answer.h
+++ b/include/knowrob/queries/Answer.h
@@ -25,8 +25,6 @@ namespace knowrob {
 				  frame_(other.frame_),
 				  reasonerTerm_(other.reasonerTerm_) {};
 
-		virtual ~Answer() = default;
-
 		/**
 		 * The answer is framed in the context of a graph selector which determines
 		 * the set of graphs in which the answer is valid.

--- a/include/knowrob/queries/AnswerTransformer.h
+++ b/include/knowrob/queries/AnswerTransformer.h
@@ -1,6 +1,7 @@
-//
-// Created by daniel on 22.04.23.
-//
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
 
 #ifndef KNOWROB_ANSWER_TRANSFORMER_H
 #define KNOWROB_ANSWER_TRANSFORMER_H

--- a/include/knowrob/queries/DisjunctiveBroadcaster.h
+++ b/include/knowrob/queries/DisjunctiveBroadcaster.h
@@ -1,6 +1,7 @@
-//
-// Created by daniel on 30.01.24.
-//
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
 
 #ifndef KNOWROB_ANSWER_CONSOLIDATOR_H
 #define KNOWROB_ANSWER_CONSOLIDATOR_H

--- a/include/knowrob/queries/Query.h
+++ b/include/knowrob/queries/Query.h
@@ -11,8 +11,15 @@
 #include "QueryContext.h"
 
 namespace knowrob {
+	/**
+	 * @return a query context that selects the default graph, i.e. the one that represents
+	 *          the current state of the world from the perspective of the robot.
+	 */
 	QueryContextPtr DefaultQueryContext();
 
+	/**
+	 * @return same as DefaultQueryContext() but with the QUERY_FLAG_ONE_SOLUTION flag set.
+	 */
 	QueryContextPtr OneSolutionContext();
 
 	/**

--- a/include/knowrob/queries/QueryContext.h
+++ b/include/knowrob/queries/QueryContext.h
@@ -10,16 +10,9 @@
 
 #include "knowrob/formulas/ModalOperator.h"
 #include "knowrob/triples/GraphSelector.h"
+#include "knowrob/queries/QueryFlag.h"
 
 namespace knowrob {
-	enum QueryFlag {
-		QUERY_FLAG_ALL_SOLUTIONS = 1 << 0,
-		QUERY_FLAG_ONE_SOLUTION = 1 << 1,
-		QUERY_FLAG_PERSIST_SOLUTIONS = 1 << 2,
-		QUERY_FLAG_UNIQUE_SOLUTIONS = 1 << 3,
-		//QUERY_FLAG_ORDER_PRESERVING = 1 << 4,
-	};
-
 	/**
 	 * The context in which a query is evaluated.
 	 */

--- a/include/knowrob/queries/QueryError.h
+++ b/include/knowrob/queries/QueryError.h
@@ -1,7 +1,4 @@
 /*
- * Copyright (c) 2022, Daniel Beßler
- * All rights reserved.
- *
  * This file is part of KnowRob, please consult
  * https://github.com/knowrob/knowrob for license details.
  */

--- a/include/knowrob/queries/QueryFlag.h
+++ b/include/knowrob/queries/QueryFlag.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#ifndef KNOWROB_QUERY_FLAG_H
+#define KNOWROB_QUERY_FLAG_H
+
+namespace knowrob {
+	/**
+	 * Flags for controlling query evaluation.
+	 */
+	enum QueryFlag {
+		/** Query all solutions. */
+		QUERY_FLAG_ALL_SOLUTIONS = 1 << 0,
+		/** Query only one solution. */
+		QUERY_FLAG_ONE_SOLUTION = 1 << 1,
+		/** Persist solutions in the data base. */
+		QUERY_FLAG_PERSIST_SOLUTIONS = 1 << 2,
+		/** Filter redundant solutions. */
+		QUERY_FLAG_UNIQUE_SOLUTIONS = 1 << 3,
+	};
+}
+
+#endif //KNOWROB_QUERY_FLAG_H

--- a/include/knowrob/queries/QueryPipeline.h
+++ b/include/knowrob/queries/QueryPipeline.h
@@ -70,6 +70,11 @@ namespace knowrob {
 				const QueryContextPtr &ctx);
 	};
 
+	/**
+	 * A buffer that holds a reference to a query pipeline.
+	 * This is used such that the underlying pipeline is destroyed once the
+	 * user drops the reference to the buffer.
+	 */
 	class AnswerBuffer_WithReference : public TokenBuffer {
 	public:
 		explicit AnswerBuffer_WithReference(const std::shared_ptr<QueryPipeline> &pipeline)

--- a/include/knowrob/queries/QueryPipeline.h
+++ b/include/knowrob/queries/QueryPipeline.h
@@ -64,7 +64,7 @@ namespace knowrob {
 
 		void createComputationPipeline(
 				const std::shared_ptr<KnowledgeBase> &kb,
-				const std::vector<RDFComputablePtr> &computableLiterals,
+				std::vector<RDFComputablePtr> &computableLiterals,
 				const std::shared_ptr<TokenBroadcaster> &pipelineInput,
 				const std::shared_ptr<TokenBroadcaster> &pipelineOutput,
 				const QueryContextPtr &ctx);
@@ -74,6 +74,7 @@ namespace knowrob {
 	public:
 		explicit AnswerBuffer_WithReference(const std::shared_ptr<QueryPipeline> &pipeline)
 				: TokenBuffer(), pipeline_(pipeline) {}
+
 	protected:
 		std::shared_ptr<QueryPipeline> pipeline_;
 	};

--- a/include/knowrob/queries/QueryPipeline.h
+++ b/include/knowrob/queries/QueryPipeline.h
@@ -62,7 +62,7 @@ namespace knowrob {
 				const std::shared_ptr<KnowledgeBase> &kb,
 				const std::list<DependencyNodePtr> &dependencyGroup);
 
-		void createComputationPipeline(
+		static void createComputationPipeline(
 				const std::shared_ptr<KnowledgeBase> &kb,
 				std::vector<RDFComputablePtr> &computableLiterals,
 				const std::shared_ptr<TokenBroadcaster> &pipelineInput,

--- a/include/knowrob/queries/QueryStage.h
+++ b/include/knowrob/queries/QueryStage.h
@@ -55,12 +55,13 @@ namespace knowrob {
 		std::atomic<bool> hasStopRequest_;
 		std::atomic<bool> hasPositiveAnswer_;
 		std::weak_ptr<QueryStage> selfWeakRef_;
-		std::vector<AnswerNoPtr> deferredNegativeAnswers_;
-		std::vector<AnswerDontKnowPtr> deferredDontKnowAnswers_;
 
 		using ActiveQuery = std::pair<TokenBufferPtr, std::shared_ptr<TokenStream>>;
 		using ActiveQueryIter = std::list<ActiveQuery>::iterator;
 		std::list<ActiveQuery> activeQueries_;
+		std::vector<AnswerNoPtr> deferredNegativeAnswers_;
+		std::vector<AnswerDontKnowPtr> deferredDontKnowAnswers_;
+		std::mutex activeQueryLock_;
 		QueryContextPtr ctx_;
 
 		/**

--- a/include/knowrob/queries/QueryStage.h
+++ b/include/knowrob/queries/QueryStage.h
@@ -122,6 +122,40 @@ namespace knowrob {
 			return submitter_(instance);
 		}
 	};
+
+	/**
+	 * A typed query stage that submits instances of a specific query type.
+	 */
+	template<class QueryType>
+	class TypedQueryStageVec : public QueryStage {
+	public:
+		/**
+		 * A lambda expression used to submit instances of the input query.
+		 */
+		using QuerySubmitter = std::function<TokenBufferPtr(const std::vector<std::shared_ptr<QueryType>> &)>;
+
+		TypedQueryStageVec(const QueryContextPtr &ctx,
+						const std::vector<std::shared_ptr<QueryType>> &query,
+						const QuerySubmitter &submitter)
+				: QueryStage(ctx),
+				  query_(query),
+				  submitter_(submitter) {}
+
+	protected:
+		const std::vector<std::shared_ptr<QueryType>> query_;
+		QuerySubmitter submitter_;
+
+		// override QueryStage
+		TokenBufferPtr submitQuery(const Bindings &substitution) override {
+			// apply the substitution mapping
+			std::vector<std::shared_ptr<QueryType>> instances(query_.size());
+			for (int i = 0; i < query_.size(); i++) {
+				instances[i] = applyBindings(query_[i], substitution);
+			}
+			// submit a query
+			return submitter_(instances);
+		}
+	};
 } // knowrob
 
 #endif //KNOWROB_QUERY_STAGE_H

--- a/include/knowrob/queries/QueryStage.h
+++ b/include/knowrob/queries/QueryStage.h
@@ -135,8 +135,8 @@ namespace knowrob {
 		using QuerySubmitter = std::function<TokenBufferPtr(const std::vector<std::shared_ptr<QueryType>> &)>;
 
 		TypedQueryStageVec(const QueryContextPtr &ctx,
-						const std::vector<std::shared_ptr<QueryType>> &query,
-						const QuerySubmitter &submitter)
+						   const std::vector<std::shared_ptr<QueryType>> &query,
+						   const QuerySubmitter &submitter)
 				: QueryStage(ctx),
 				  query_(query),
 				  submitter_(submitter) {}

--- a/include/knowrob/queries/QueryTree.h
+++ b/include/knowrob/queries/QueryTree.h
@@ -1,6 +1,7 @@
-//
-// Created by daniel on 21.03.23.
-//
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
 
 #ifndef KNOWROB_QUERY_TREE_H
 #define KNOWROB_QUERY_TREE_H

--- a/include/knowrob/queries/QueryTree.h
+++ b/include/knowrob/queries/QueryTree.h
@@ -17,107 +17,110 @@
 #include "knowrob/formulas/FirstOrderLiteral.h"
 
 namespace knowrob {
-    /**
-     * Constructs a tableau-like tree by decomposing an input formula.
-     */
-    class QueryTree {
-    public:
-        explicit QueryTree(const FormulaPtr &query);
+	/**
+	 * Constructs a tableau-like tree by decomposing an input formula.
+	 */
+	class QueryTree {
+	public:
+		explicit QueryTree(const FormulaPtr &query);
 
-        ~QueryTree();
+		~QueryTree();
 
-        QueryTree(const QueryTree&) = delete;
+		QueryTree(const QueryTree &) = delete;
 
-        /**
-         * @return number of paths from root of the tree to leafs.
-         */
-        auto numPaths() const { return paths_.size(); }
+		/**
+		 * @return number of paths from root of the tree to leafs.
+		 */
+		auto numPaths() const { return paths_.size(); }
 
-        /**
-         * @return list of paths from root of the tree to leafs.
-         */
-        const auto& paths() const { return paths_; }
+		/**
+		 * @return list of paths from root of the tree to leafs.
+		 */
+		const auto &paths() const { return paths_; }
 
-        /**
-         * @return begin iterator over paths from root to leafs.
-         */
-        auto begin() const { return paths_.begin(); }
+		/**
+		 * @return begin iterator over paths from root to leafs.
+		 */
+		auto begin() const { return paths_.begin(); }
 
-        /**
-         * @return end iterator over paths from root to leafs.
-         */
-        auto end() const { return paths_.end(); }
+		/**
+		 * @return end iterator over paths from root to leafs.
+		 */
+		auto end() const { return paths_.end(); }
 
-        /**
-         * A node in a QueryTree.
-         */
-        class Node {
-        public:
-            Node(Node *parent, FormulaPtr formula, bool isNegated);
-            Node *parent;
-            const FormulaPtr formula;
-            bool isNegated;
-            bool isOpen;
-            std::list<Node*> successors;
+		/**
+		 * A node in a QueryTree.
+		 */
+		class Node {
+		public:
+			Node(Node *parent, FormulaPtr formula, bool isNegated);
 
-            int priority() const;
-        };
+			Node *parent;
+			const FormulaPtr formula;
+			bool isNegated;
+			bool isOpen;
+			std::list<Node *> successors;
 
-        /**
-         * A path in a QueryTree from root of the tree to a leaf.
-         */
-        class Path {
-        public:
-            Path() = default;
+			int priority() const;
+		};
 
-            /**
-             * @return number of literals in this path
-             */
-            auto numNodes() const { return nodes_.size(); }
+		/**
+		 * A path in a QueryTree from root of the tree to a leaf.
+		 */
+		class Path {
+		public:
+			Path() = default;
 
-            /**
-             * @return list of literals
-             */
-            const auto& nodes() const { return nodes_; }
+			/**
+			 * @return number of literals in this path
+			 */
+			auto numNodes() const { return nodes_.size(); }
 
-            /**
-             * @return begin iterator over literals in a path.
-             */
-            auto begin() const { return nodes_.begin(); }
+			/**
+			 * @return list of literals
+			 */
+			const auto &nodes() const { return nodes_; }
 
-            /**
-             * @return end iterator over literals in a path.
-             */
-            auto end() const { return nodes_.end(); }
+			/**
+			 * @return begin iterator over literals in a path.
+			 */
+			auto begin() const { return nodes_.begin(); }
 
-            std::shared_ptr<Formula> toFormula() const;
+			/**
+			 * @return end iterator over literals in a path.
+			 */
+			auto end() const { return nodes_.end(); }
 
-        protected:
-            std::vector<FormulaPtr> nodes_;
-            friend class QueryTree;
-        };
+			std::shared_ptr<Formula> toFormula() const;
 
-    protected:
-        const FormulaPtr query_;
-        std::list<Path> paths_;
+		protected:
+			std::vector<FormulaPtr> nodes_;
 
-        Node* rootNode_;
+			friend class QueryTree;
+		};
 
-        struct NodeComparator {
-            bool operator()(const Node *a, const Node *b) const;
-        };
-        std::priority_queue<Node*, std::vector<Node*>, NodeComparator> openNodes_;
+	protected:
+		const FormulaPtr query_;
+		std::list<Path> paths_;
 
-        Node* createNode(Node *parent, const FormulaPtr &phi, bool isNegated);
+		Node *rootNode_;
 
-        static std::list<QueryTree::Node*> getLeafs(Node *n);
+		struct NodeComparator {
+			bool operator()(const Node *a, const Node *b) const;
+		};
 
-        static bool hasCompletePath(Node *leaf);
+		std::priority_queue<Node *, std::vector<Node *>, NodeComparator> openNodes_;
 
-        static void constructPath(Node *leaf, Path &path);
+		Node *createNode(Node *parent, const FormulaPtr &phi, bool isNegated);
 
-        void expandNextNode();
-    };
+		static std::list<QueryTree::Node *> getLeafs(Node *n);
+
+		static bool hasCompletePath(Node *leaf);
+
+		static void constructPath(Node *leaf, Path &path);
+
+		void expandNextNode();
+	};
 
 } // knowrob
 

--- a/include/knowrob/queries/RedundantAnswerFilter.h
+++ b/include/knowrob/queries/RedundantAnswerFilter.h
@@ -1,6 +1,7 @@
-//
-// Created by daniel on 30.07.23.
-//
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
 
 #ifndef KNOWROB_REDUNDANT_ANSWER_FILTER_H
 #define KNOWROB_REDUNDANT_ANSWER_FILTER_H

--- a/include/knowrob/queries/RedundantAnswerFilter.h
+++ b/include/knowrob/queries/RedundantAnswerFilter.h
@@ -10,7 +10,9 @@
 #include "TokenBroadcaster.h"
 
 namespace knowrob {
-
+	/**
+	 * A filter stage that removes redundant answers.
+	 */
 	class RedundantAnswerFilter : public TokenBroadcaster {
 	public:
 		RedundantAnswerFilter() = default;

--- a/include/knowrob/queries/TokenQueue.h
+++ b/include/knowrob/queries/TokenQueue.h
@@ -13,7 +13,7 @@
 
 namespace knowrob {
 	/**
-	 * A queue of QueryResult objects.
+	 * A queue of query results.
 	 */
 	class TokenQueue : public TokenStream {
 	public:

--- a/include/knowrob/queries/TokenStream.h
+++ b/include/knowrob/queries/TokenStream.h
@@ -25,12 +25,15 @@ namespace knowrob {
 
 		virtual ~TokenStream();
 
+		/**
+		 * Cannot be copy-assigned.
+		 */
 		TokenStream(const TokenStream &) = delete;
 
 		/**
 		 * Close the stream.
 		 * This will push an EOS message, and all future
-		 * attempts to push a non EOS message will cause an error.
+		 * attempts to push a non EOS message will cause a warning.
 		 * Once closed, a stream cannot be opened again.
 		 * Note that a stream auto-closes once it has received EOS
 		 * messages from all of its input channels.
@@ -48,7 +51,7 @@ namespace knowrob {
 		class Channel {
 		public:
 			/**
-			 * @param stream the query result stream associated to this channel.
+			 * @param stream the stream associated to this channel.
 			 */
 			explicit Channel(const std::shared_ptr<TokenStream> &stream);
 
@@ -115,7 +118,6 @@ namespace knowrob {
 		std::list<std::shared_ptr<Channel>> channels_;
 		std::atomic<bool> isOpened_;
 		std::mutex channel_mutex_;
-		//uint32_t numCompletedChannels_;
 
 		virtual void push(Channel &channel, const TokenPtr &tok);
 

--- a/include/knowrob/reasoner/GoalDrivenReasoner.h
+++ b/include/knowrob/reasoner/GoalDrivenReasoner.h
@@ -21,10 +21,10 @@ namespace knowrob {
 		 */
 		SupportsSimpleConjunctions = 0x01,
 		/**
-		 * Responses from the reasoner include factual knowledge
-		 * stored in its backend.
+		 * The reasoner can ground literals in extensional knowledge, i.e. in the
+		 * factual data contained in its storage backend.
 		 */
-		IncludesFactualKnowledge = 0x02,
+		SupportsExtensionalGrounding = 0x02,
 	};
 
 	/**

--- a/include/knowrob/reasoner/GoalDrivenReasoner.h
+++ b/include/knowrob/reasoner/GoalDrivenReasoner.h
@@ -20,6 +20,11 @@ namespace knowrob {
 		 * A simple conjunction is a conjunction of literals.
 		 */
 		SupportsSimpleConjunctions = 0x01,
+		/**
+		 * Responses from the reasoner include factual knowledge
+		 * stored in its backend.
+		 */
+		IncludesFactualKnowledge = 0x02,
 	};
 
 	/**

--- a/include/knowrob/reasoner/GoalDrivenReasoner.h
+++ b/include/knowrob/reasoner/GoalDrivenReasoner.h
@@ -18,11 +18,15 @@ namespace knowrob {
 		/**
 		 * The reasoner supports simple conjunctions.
 		 * A simple conjunction is a conjunction of literals.
+		 * If this feature is not enabled, the reasoner will only receive queries
+		 * that contain a single literal.
 		 */
 		SupportsSimpleConjunctions = 0x01,
 		/**
 		 * The reasoner can ground literals in extensional knowledge, i.e. in the
 		 * factual data contained in its storage backend.
+		 * Note that if this feature is enabled, the reasoner is expected to
+		 * provide all extensional groundings for a literal if not told otherwise.
 		 */
 		SupportsExtensionalGrounding = 0x02,
 	};

--- a/include/knowrob/reasoner/ReasonerManager.h
+++ b/include/knowrob/reasoner/ReasonerManager.h
@@ -76,7 +76,7 @@ namespace knowrob {
 		 */
 		static TokenBufferPtr evaluateQuery(
 				const GoalDrivenReasonerPtr &reasoner,
-				const FirstOrderLiteralPtr &literal,
+				const std::vector<FirstOrderLiteralPtr> &literals,
 				const QueryContextPtr &ctx);
 
 	private:

--- a/src/formulas/FirstOrderLiteral.cpp
+++ b/src/formulas/FirstOrderLiteral.cpp
@@ -27,6 +27,18 @@ std::ostream &FirstOrderLiteral::write(std::ostream &os) const {
 	return os;
 }
 
+namespace knowrob {
+	FirstOrderLiteralPtr applyBindings(const FirstOrderLiteralPtr &lit, const Bindings &bindings) {
+		auto predicate = std::static_pointer_cast<Predicate>(applyBindings(lit->predicate(), bindings));
+		if (predicate != lit->predicate()) {
+			return std::make_shared<FirstOrderLiteral>(predicate, lit->isNegated());
+		}
+		else {
+			return lit;
+		}
+	}
+}
+
 namespace knowrob::py {
 	template<>
 	void createType<FirstOrderLiteral>() {

--- a/src/queries/Answer.cpp
+++ b/src/queries/Answer.cpp
@@ -178,8 +178,8 @@ namespace knowrob::py {
 				.def("stringFormOfAnswer", &Answer::stringFormOfAnswer)
 				.def("humanReadableForm", &Answer::humanReadableForm);
 		// Allow implicit conversion from shared_ptr<Answer> to shared_ptr<const Answer>
-		register_ptr_to_python< std::shared_ptr< const Answer > >();
-		implicitly_convertible< std::shared_ptr< Answer >, std::shared_ptr< const Answer > >();
+		register_ptr_to_python<std::shared_ptr<const Answer> >();
+		implicitly_convertible<std::shared_ptr<Answer>, std::shared_ptr<const Answer> >();
 		// Create subtypes
 		createType<AnswerYes>();
 		createType<AnswerNo>();

--- a/src/queries/AnswerDontKnow.cpp
+++ b/src/queries/AnswerDontKnow.cpp
@@ -46,7 +46,7 @@ namespace knowrob::py {
 				.def("stringFormOfDontKnow", &AnswerDontKnow::stringFormOfDontKnow)
 				.def("humanReadableFormOfDontKnow", &AnswerDontKnow::humanReadableFormOfDontKnow);
 		// Allow implicit conversion of shared_ptr< AnswerDontKnow > to shared_ptr< const AnswerDontKnow >
-		register_ptr_to_python< std::shared_ptr< const AnswerDontKnow > >();
-		implicitly_convertible< std::shared_ptr< AnswerDontKnow >, std::shared_ptr< const AnswerDontKnow > >();
+		register_ptr_to_python<std::shared_ptr<const AnswerDontKnow> >();
+		implicitly_convertible<std::shared_ptr<AnswerDontKnow>, std::shared_ptr<const AnswerDontKnow> >();
 	}
 }

--- a/src/queries/AnswerNo.cpp
+++ b/src/queries/AnswerNo.cpp
@@ -109,7 +109,7 @@ namespace knowrob::py {
 				.def("stringFormOfNo", &AnswerNo::stringFormOfNo)
 				.def("humanReadableFormOfNo", &AnswerNo::humanReadableFormOfNo);
 		// Allow implicit conversion from AnswerNo to const AnswerNo
-		register_ptr_to_python< std::shared_ptr< const AnswerNo > >();
-		implicitly_convertible< std::shared_ptr< AnswerNo >, std::shared_ptr< const AnswerNo > >();
+		register_ptr_to_python<std::shared_ptr<const AnswerNo> >();
+		implicitly_convertible<std::shared_ptr<AnswerNo>, std::shared_ptr<const AnswerNo> >();
 	}
 }

--- a/src/queries/AnswerYes.cpp
+++ b/src/queries/AnswerYes.cpp
@@ -205,7 +205,7 @@ namespace knowrob::py {
 				.def("isRicherThan", &AnswerYes::isRicherThan)
 				.def("isGenericYes", &AnswerYes::isGenericYes);
 		// Allow implicit conversion from AnswerYes to const AnswerYes
-		register_ptr_to_python< std::shared_ptr< const AnswerYes > >();
-		implicitly_convertible< std::shared_ptr< AnswerYes >, std::shared_ptr< const AnswerYes > >();
+		register_ptr_to_python<std::shared_ptr<const AnswerYes> >();
+		implicitly_convertible<std::shared_ptr<AnswerYes>, std::shared_ptr<const AnswerYes> >();
 	}
 }

--- a/src/queries/ConjunctiveBroadcaster.cpp
+++ b/src/queries/ConjunctiveBroadcaster.cpp
@@ -9,7 +9,6 @@
 #include "knowrob/queries/AnswerYes.h"
 #include "knowrob/queries/Answer.h"
 #include "knowrob/terms/Numeric.h"
-#include "knowrob/knowrob.h"
 
 using namespace knowrob;
 

--- a/src/queries/NegationStage.cpp
+++ b/src/queries/NegationStage.cpp
@@ -71,7 +71,7 @@ bool PredicateNegationStage::succeeds(const AnswerYesPtr &answer) {
 		auto l_reasoner = kb_->reasonerManager()->getReasonerForRelation(
 				PredicateIndicator(l_property_a->stringForm(), 2));
 		for (auto &r: l_reasoner) {
-			results.push_back(ReasonerManager::evaluateQuery(r, instance, ctx_));
+			results.push_back(ReasonerManager::evaluateQuery(r, {instance}, ctx_));
 		}
 	}
 

--- a/src/queries/QueryContext.cpp
+++ b/src/queries/QueryContext.cpp
@@ -14,7 +14,7 @@ namespace knowrob::py {
 		using namespace boost::python;
 
 		enum_<QueryFlag>("QueryFlag")
-		        .value("QUERY_FLAG_ALL_SOLUTIONS", QUERY_FLAG_ALL_SOLUTIONS)
+				.value("QUERY_FLAG_ALL_SOLUTIONS", QUERY_FLAG_ALL_SOLUTIONS)
 				.value("QUERY_FLAG_ONE_SOLUTION", QUERY_FLAG_ONE_SOLUTION)
 				.value("QUERY_FLAG_PERSIST_SOLUTIONS", QUERY_FLAG_PERSIST_SOLUTIONS)
 				.value("QUERY_FLAG_UNIQUE_SOLUTIONS", QUERY_FLAG_UNIQUE_SOLUTIONS)
@@ -29,7 +29,7 @@ namespace knowrob::py {
 
 		// QueryContextPtr uses `const QueryContext` which currently requires
 		// a custom converter to be defined in order to be used in Python.
-		register_ptr_to_python< std::shared_ptr< const QueryContext > >();
-		implicitly_convertible< std::shared_ptr< QueryContext >, std::shared_ptr< const QueryContext > >();
+		register_ptr_to_python<std::shared_ptr<const QueryContext> >();
+		implicitly_convertible<std::shared_ptr<QueryContext>, std::shared_ptr<const QueryContext> >();
 	}
 }

--- a/src/queries/QueryContext.cpp
+++ b/src/queries/QueryContext.cpp
@@ -5,7 +5,7 @@
 
 #include "knowrob/queries/QueryContext.h"
 #include "knowrob/integration/python/utils.h"
-#include "QueryFlag.h"
+#include "knowrob/queries/QueryFlag.h"
 
 using namespace knowrob;
 

--- a/src/queries/QueryContext.cpp
+++ b/src/queries/QueryContext.cpp
@@ -5,6 +5,7 @@
 
 #include "knowrob/queries/QueryContext.h"
 #include "knowrob/integration/python/utils.h"
+#include "QueryFlag.h"
 
 using namespace knowrob;
 

--- a/src/queries/QueryParser.cpp
+++ b/src/queries/QueryParser.cpp
@@ -1,5 +1,4 @@
-/*// Define value types for options
-using OptionValue = variant<string, double, int, optional<long long>>;
+/*
  * This file is part of KnowRob, please consult
  * https://github.com/knowrob/knowrob for license details.
  */

--- a/src/queries/QueryPipeline.cpp
+++ b/src/queries/QueryPipeline.cpp
@@ -129,7 +129,6 @@ QueryPipeline::QueryPipeline(const std::shared_ptr<KnowledgeBase> &kb, const For
 		// TODO: compute dependency between modals, evaluate independent modals in parallel.
 		//       they could also be independent in evaluation context only, we could check which variables receive
 		//       grounding already before in posLiteral query!
-		//       this is effectively what is done in submitQuery(pathQuery)
 		// --------------------------------------
 		for (auto &posModal: posModals) {
 			auto modalStage = std::make_shared<ModalStage>(kb, posModal, ctx);
@@ -163,7 +162,7 @@ QueryPipeline::QueryPipeline(const std::shared_ptr<KnowledgeBase> &kb, const For
 		lastStage >> outStream;
 		firstBuffer->stopBuffering();
 	}
-	// At this point outStream could already contain solutions, but these are buffered
+	// Note: At this point outStream could already contain solutions, but these are buffered
 	// such that they won't be lost during pipeline creation.
 
 	// if there were multiple paths, consolidate answers from them.

--- a/src/queries/QueryStage.cpp
+++ b/src/queries/QueryStage.cpp
@@ -12,6 +12,7 @@
 #include "knowrob/queries/AnswerYes.h"
 #include "knowrob/queries/AnswerMerger.h"
 #include "knowrob/queries/AnswerNo.h"
+#include "QueryFlag.h"
 
 using namespace knowrob;
 

--- a/src/queries/QueryStage.cpp
+++ b/src/queries/QueryStage.cpp
@@ -33,10 +33,12 @@ void QueryStage::close() {
 	// toggle on stop request
 	hasStopRequest_ = true;
 
-	auto activeQueries = activeQueries_;
+	std::list<ActiveQuery> activeQueries;
 	{
 		std::lock_guard<std::mutex> lock(activeQueryLock_);
+		activeQueries = activeQueries_;
 		activeQueries_.clear();
+		isQueryOpened_ = false;
 	}
 	for (auto &x: activeQueries) {
 		x.first->close();

--- a/src/queries/QueryStage.cpp
+++ b/src/queries/QueryStage.cpp
@@ -12,7 +12,6 @@
 #include "knowrob/queries/AnswerYes.h"
 #include "knowrob/queries/AnswerMerger.h"
 #include "knowrob/queries/AnswerNo.h"
-#include "QueryFlag.h"
 
 using namespace knowrob;
 

--- a/src/queries/QueryTree.cpp
+++ b/src/queries/QueryTree.cpp
@@ -13,215 +13,196 @@ using namespace knowrob;
 using namespace knowrob::modals;
 
 QueryTree::QueryTree(const FormulaPtr &query)
-: rootNode_(new Node(nullptr, query, false))
-{
-    openNodes_.push(rootNode_);
-    while(!openNodes_.empty()) {
-        expandNextNode();
-    }
+		: rootNode_(new Node(nullptr, query, false)) {
+	openNodes_.push(rootNode_);
+	while (!openNodes_.empty()) {
+		expandNextNode();
+	}
 }
 
-QueryTree::~QueryTree()
-{
-    std::list<Node*> fifo;
-    fifo.push_back(rootNode_);
-    while(!fifo.empty()) {
-        Node *next = fifo.front();
-        fifo.pop_front();
-        for (auto *x: next->successors) {
-            fifo.push_back(x);
-        }
-        delete next;
-    }
-    rootNode_ = nullptr;
+QueryTree::~QueryTree() {
+	std::list<Node *> fifo;
+	fifo.push_back(rootNode_);
+	while (!fifo.empty()) {
+		Node *next = fifo.front();
+		fifo.pop_front();
+		for (auto *x: next->successors) {
+			fifo.push_back(x);
+		}
+		delete next;
+	}
+	rootNode_ = nullptr;
 }
 
 QueryTree::Node::Node(Node *parent, FormulaPtr formula, bool isNegated)
-: parent(parent),
-  formula(std::move(formula)),
-  isNegated(isNegated),
-  isOpen(true)
-{
+		: parent(parent),
+		  formula(std::move(formula)),
+		  isNegated(isNegated),
+		  isOpen(true) {
 }
 
-int QueryTree::Node::priority() const
-{
-    switch(formula->type()) {
-        case FormulaType::MODAL:
-        case FormulaType::NEGATION:
-        case FormulaType::PREDICATE:
-            return 1;
-        case FormulaType::CONJUNCTION:
-            return isNegated ? 0 : 1;
-        case FormulaType::DISJUNCTION:
-        case FormulaType::IMPLICATION:
-            return isNegated ? 1 : 0;
-    }
+int QueryTree::Node::priority() const {
+	switch (formula->type()) {
+		case FormulaType::MODAL:
+		case FormulaType::NEGATION:
+		case FormulaType::PREDICATE:
+			return 1;
+		case FormulaType::CONJUNCTION:
+			return isNegated ? 0 : 1;
+		case FormulaType::DISJUNCTION:
+		case FormulaType::IMPLICATION:
+			return isNegated ? 1 : 0;
+	}
 	return 0;
 }
 
-bool QueryTree::NodeComparator::operator()(const Node *a, const Node *b) const
-{
-    int priority_a = a->priority();
-    int priority_b = b->priority();
-    if(priority_a != priority_b) {
-        return priority_a < priority_b;
-    }
-    else {
-        return a < b;
-    }
+bool QueryTree::NodeComparator::operator()(const Node *a, const Node *b) const {
+	int priority_a = a->priority();
+	int priority_b = b->priority();
+	if (priority_a != priority_b) {
+		return priority_a < priority_b;
+	} else {
+		return a < b;
+	}
 }
 
-std::list<QueryTree::Node*> QueryTree::getLeafs(Node *n)
-{
-    std::list<Node*> out;
-    std::list<Node*> fifo;
-    fifo.push_back(n);
-    while(!fifo.empty()) {
-         Node *next = fifo.front();
-         fifo.pop_front();
-         if(next->successors.empty()) {
-             out.push_back(next);
-         }
-         else {
-             for(auto *x : next->successors) {
-                 fifo.push_back(x);
-             }
-         }
-    }
-    return out;
+std::list<QueryTree::Node *> QueryTree::getLeafs(Node *n) {
+	std::list<Node *> out;
+	std::list<Node *> fifo;
+	fifo.push_back(n);
+	while (!fifo.empty()) {
+		Node *next = fifo.front();
+		fifo.pop_front();
+		if (next->successors.empty()) {
+			out.push_back(next);
+		} else {
+			for (auto *x: next->successors) {
+				fifo.push_back(x);
+			}
+		}
+	}
+	return out;
 }
 
-QueryTree::Node* QueryTree::createNode(Node *parent, const FormulaPtr &phi, bool isNegated)
-{
-    Node *newNode = new Node(parent, phi, isNegated);
-    parent->successors.push_back(newNode);
-    openNodes_.push(newNode);
-    return newNode;
+QueryTree::Node *QueryTree::createNode(Node *parent, const FormulaPtr &phi, bool isNegated) {
+	Node *newNode = new Node(parent, phi, isNegated);
+	parent->successors.push_back(newNode);
+	openNodes_.push(newNode);
+	return newNode;
 }
 
-bool QueryTree::hasCompletePath(Node *leaf)
-{
-    Node *parent = leaf;
-    do {
-        if(parent->isOpen) return false;
-        parent = parent->parent;
-    } while(parent);
-    return true;
+bool QueryTree::hasCompletePath(Node *leaf) {
+	Node *parent = leaf;
+	do {
+		if (parent->isOpen) return false;
+		parent = parent->parent;
+	} while (parent);
+	return true;
 }
 
-void QueryTree::constructPath(Node *leaf, Path &path)
-{
-    Node *parent = leaf;
-    do {
-        if(parent->formula->type() == FormulaType::PREDICATE ||
-           parent->formula->type() == FormulaType::MODAL) {
-            if(parent->isNegated) {
-            	path.nodes_.push_back(std::make_shared<Negation>(parent->formula));
-            }
-            else {
-            	path.nodes_.push_back(parent->formula);
-            }
-        }
-        parent = parent->parent;
-    } while(parent);
+void QueryTree::constructPath(Node *leaf, Path &path) {
+	Node *parent = leaf;
+	do {
+		if (parent->formula->type() == FormulaType::PREDICATE ||
+			parent->formula->type() == FormulaType::MODAL) {
+			if (parent->isNegated) {
+				path.nodes_.push_back(std::make_shared<Negation>(parent->formula));
+			} else {
+				path.nodes_.push_back(parent->formula);
+			}
+		}
+		parent = parent->parent;
+	} while (parent);
 }
 
-void QueryTree::expandNextNode()
-{
-    auto next = openNodes_.top();
-    next->isOpen = false;
-    openNodes_.pop();
+void QueryTree::expandNextNode() {
+	auto next = openNodes_.top();
+	next->isOpen = false;
+	openNodes_.pop();
 
-    switch(next->formula->type()) {
-        case FormulaType::PREDICATE:
-        case FormulaType::MODAL:
-            for(Node *leaf : getLeafs(next)) {
-                if(hasCompletePath(leaf)) {
-                    paths_.emplace_back();
-                    auto &path = paths_.back();
-                    constructPath(leaf, path);
-                }
-            }
-            break;
+	switch (next->formula->type()) {
+		case FormulaType::PREDICATE:
+		case FormulaType::MODAL:
+			for (Node *leaf: getLeafs(next)) {
+				if (hasCompletePath(leaf)) {
+					paths_.emplace_back();
+					auto &path = paths_.back();
+					constructPath(leaf, path);
+				}
+			}
+			break;
 
-        case FormulaType::CONJUNCTION: {
-            auto *formula = (Conjunction*)next->formula.get();
-            if(next->isNegated) {
-                for(Node *leaf : getLeafs(next)) {
-                    for(auto &phi : formula->formulae()) {
-                        createNode(leaf, phi, true);
-                    }
-                }
-            }
-            else {
-                for(Node *leaf : getLeafs(next)) {
-                    Node *parent = leaf;
-                    for (auto &phi: formula->formulae()) {
-                        parent = createNode(parent, phi, false);
-                    }
-                }
-            }
-            break;
-        }
+		case FormulaType::CONJUNCTION: {
+			auto *formula = (Conjunction *) next->formula.get();
+			if (next->isNegated) {
+				for (Node *leaf: getLeafs(next)) {
+					for (auto &phi: formula->formulae()) {
+						createNode(leaf, phi, true);
+					}
+				}
+			} else {
+				for (Node *leaf: getLeafs(next)) {
+					Node *parent = leaf;
+					for (auto &phi: formula->formulae()) {
+						parent = createNode(parent, phi, false);
+					}
+				}
+			}
+			break;
+		}
 
-        case FormulaType::DISJUNCTION: {
-            auto *formula = (Disjunction*)next->formula.get();
-            if(next->isNegated) {
-                for(Node *leaf : getLeafs(next)) {
-                    Node *parent = leaf;
-                    for (auto &phi: formula->formulae()) {
-                        parent = createNode(parent, phi, true);
-                    }
-                }
-            }
-            else {
-                for(Node *leaf : getLeafs(next)) {
-                    for (auto &phi: formula->formulae()) {
-                        createNode(leaf, phi, false);
-                    }
-                }
-            }
-            break;
-        }
+		case FormulaType::DISJUNCTION: {
+			auto *formula = (Disjunction *) next->formula.get();
+			if (next->isNegated) {
+				for (Node *leaf: getLeafs(next)) {
+					Node *parent = leaf;
+					for (auto &phi: formula->formulae()) {
+						parent = createNode(parent, phi, true);
+					}
+				}
+			} else {
+				for (Node *leaf: getLeafs(next)) {
+					for (auto &phi: formula->formulae()) {
+						createNode(leaf, phi, false);
+					}
+				}
+			}
+			break;
+		}
 
-        case FormulaType::IMPLICATION: {
-            auto *formula = (Implication*)next->formula.get();
-            if(next->isNegated) {
-                for(Node *leaf : getLeafs(next)) {
-                    Node *parent = leaf;
-                    parent = createNode(parent, formula->antecedent(), false);
-                    createNode(parent, formula->consequent(), true);
-                }
-            }
-            else {
-                for(Node *leaf : getLeafs(next)) {
-                    createNode(leaf, formula->antecedent(), true);
-                    createNode(leaf, formula->consequent(), false);
-                }
-            }
-            break;
-        }
+		case FormulaType::IMPLICATION: {
+			auto *formula = (Implication *) next->formula.get();
+			if (next->isNegated) {
+				for (Node *leaf: getLeafs(next)) {
+					Node *parent = leaf;
+					parent = createNode(parent, formula->antecedent(), false);
+					createNode(parent, formula->consequent(), true);
+				}
+			} else {
+				for (Node *leaf: getLeafs(next)) {
+					createNode(leaf, formula->antecedent(), true);
+					createNode(leaf, formula->consequent(), false);
+				}
+			}
+			break;
+		}
 
-        case FormulaType::NEGATION: {
-            auto *formula = (Negation*)next->formula.get();
-            for(Node *leaf : getLeafs(next)) {
-                createNode(leaf, formula->negatedFormula(), !next->isNegated);
-            }
-            break;
-        }
-    }
+		case FormulaType::NEGATION: {
+			auto *formula = (Negation *) next->formula.get();
+			for (Node *leaf: getLeafs(next)) {
+				createNode(leaf, formula->negatedFormula(), !next->isNegated);
+			}
+			break;
+		}
+	}
 }
 
-std::shared_ptr<Formula> QueryTree::Path::toFormula() const
-{
-	if(nodes_.empty()) {
+std::shared_ptr<Formula> QueryTree::Path::toFormula() const {
+	if (nodes_.empty()) {
 		return Top::get();
-	}
-	else if(nodes_.size()==1) {
+	} else if (nodes_.size() == 1) {
 		return nodes_.front();
-	}
-	else {
+	} else {
 		return std::make_shared<Conjunction>(nodes_);
 	}
 }

--- a/src/queries/RedundantAnswerFilter.cpp
+++ b/src/queries/RedundantAnswerFilter.cpp
@@ -15,7 +15,7 @@ void RedundantAnswerFilter::push(const TokenPtr &tok) {
 	{
 		std::lock_guard<std::mutex> lock(mtx_);
 		count = previousAnswers_.count(msgHash);
-			previousAnswers_.insert(msgHash);
+		previousAnswers_.insert(msgHash);
 	}
 
 	if (count == 0) {

--- a/src/queries/RedundantAnswerFilter.cpp
+++ b/src/queries/RedundantAnswerFilter.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "knowrob/queries/RedundantAnswerFilter.h"
-#include "knowrob/knowrob.h"
 
 using namespace knowrob;
 

--- a/src/queries/Token.cpp
+++ b/src/queries/Token.cpp
@@ -64,8 +64,8 @@ namespace knowrob::py {
 				.def("get", &EndOfEvaluation::get, return_value_policy<reference_existing_object>())
 				.staticmethod("get");
 		// allow implicit conversion from shared_ptr<Token> to shared_ptr<const Token>
-		register_ptr_to_python< std::shared_ptr< const Token > >();
-		implicitly_convertible< std::shared_ptr< Token >, std::shared_ptr< const Token > >();
+		register_ptr_to_python<std::shared_ptr<const Token> >();
+		implicitly_convertible<std::shared_ptr<Token>, std::shared_ptr<const Token> >();
 		// create subtypes
 		createType<Answer>();
 	}

--- a/src/queries/TokenBuffer.cpp
+++ b/src/queries/TokenBuffer.cpp
@@ -73,7 +73,7 @@ TEST(TokenBuffer, twoTokens) {
 	channel->push(EndOfEvaluation::get());
 	auto queue = out->createQueue();
 	std::vector<TokenPtr> tokens;
-	while(!queue->empty()) {
+	while (!queue->empty()) {
 		auto tok = queue->pop_front();
 		tokens.push_back(tok);
 	}

--- a/src/queries/TokenStream.cpp
+++ b/src/queries/TokenStream.cpp
@@ -107,7 +107,7 @@ void TokenStream::Channel::close() {
 	std::lock_guard<std::shared_mutex> lock(mutex_);
 	if (isOpened()) {
 		isOpened_ = false;
-		if(stream_->isOpened()) {
+		if (stream_->isOpened()) {
 			stream_->push(*this, EndOfEvaluation::get());
 			stream_ = {};
 		}

--- a/src/reasoner/ReasonerManager.cpp
+++ b/src/reasoner/ReasonerManager.cpp
@@ -142,11 +142,18 @@ void ReasonerManager::initPlugin(const std::shared_ptr<NamedReasoner> &namedReas
 
 TokenBufferPtr ReasonerManager::evaluateQuery(
 		const GoalDrivenReasonerPtr &reasoner,
-		const FirstOrderLiteralPtr &literal,
+		const std::vector<FirstOrderLiteralPtr> &literals,
 		const QueryContextPtr &ctx) {
 	auto reasonerRunner = std::make_shared<ReasonerRunner>();
 	reasonerRunner->reasoner = reasoner;
-	reasonerRunner->query = std::make_shared<ReasonerQuery>(literal, ctx);
+	if(literals.size()>1) {
+		auto conjunction = std::make_shared<SimpleConjunction>(literals);
+		reasonerRunner->query = std::make_shared<ReasonerQuery>(conjunction, ctx);
+	} else if (literals.size() == 1) {
+		reasonerRunner->query = std::make_shared<ReasonerQuery>(literals[0], ctx);
+	} else {
+		throw ReasonerError("Reasoner {} received an empty query.", *reasoner->reasonerName());
+	}
 	// run reasoner in a thread
 	DefaultThreadPool()->pushWork(
 			reasonerRunner,

--- a/src/reasoner/prolog/PrologReasoner.cpp
+++ b/src/reasoner/prolog/PrologReasoner.cpp
@@ -72,6 +72,7 @@ namespace knowrob::prolog {
 PrologReasoner::PrologReasoner() : GoalDrivenReasoner() {
 	// enable goal-driven reasoning features
 	enableFeature(GoalDrivenReasonerFeature::SupportsSimpleConjunctions);
+	enableFeature(GoalDrivenReasonerFeature::IncludesFactualKnowledge);
 	// add data handler for prolog files
 	addDataHandler("prolog", [this]
 			(const DataSourcePtr &dataFile) { return consult(dataFile->uri()); });

--- a/src/reasoner/prolog/PrologReasoner.cpp
+++ b/src/reasoner/prolog/PrologReasoner.cpp
@@ -72,7 +72,7 @@ namespace knowrob::prolog {
 PrologReasoner::PrologReasoner() : GoalDrivenReasoner() {
 	// enable goal-driven reasoning features
 	enableFeature(GoalDrivenReasonerFeature::SupportsSimpleConjunctions);
-	enableFeature(GoalDrivenReasonerFeature::IncludesFactualKnowledge);
+	enableFeature(GoalDrivenReasonerFeature::SupportsExtensionalGrounding);
 	// add data handler for prolog files
 	addDataHandler("prolog", [this]
 			(const DataSourcePtr &dataFile) { return consult(dataFile->uri()); });


### PR DESCRIPTION
This PR changes query pipeline construction such that conjunctive IDB queries can be generated for some cases.

Also did reformating, QueryTree is only reformatted