### PR TITLE
GIL handling and Python interface

### DIFF
--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -160,9 +160,9 @@ namespace knowrob {
 		std::shared_ptr<Vocabulary> vocabulary_;
 		bool isInitialized_;
 
-		KnowledgeBase(const boost::property_tree::ptree &config);
+		explicit KnowledgeBase(const boost::property_tree::ptree &config);
 
-		KnowledgeBase(std::string_view config);
+		explicit KnowledgeBase(std::string_view config);
 
 		explicit KnowledgeBase();
 

--- a/include/knowrob/integration/python/utils.h
+++ b/include/knowrob/integration/python/utils.h
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include "PythonError.h"
 #include "gil.h"
+#include "with.h"
 
 namespace knowrob::py {
 	// call a method of a python object

--- a/include/knowrob/integration/python/with.h
+++ b/include/knowrob/integration/python/with.h
@@ -1,0 +1,107 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#ifndef KNOWROB_PY_WITH_H
+#define KNOWROB_PY_WITH_H
+
+#include <boost/python.hpp>
+#include <boost/function.hpp>
+#include <boost/function_types/components.hpp>
+#include <boost/function_types/function_type.hpp>
+#include <boost/function_types/result_type.hpp>
+
+namespace knowrob::py {
+	/**
+	 * Functor that will invoke a function while holding a guard.
+	 * Upon returning from the function, the guard is released.
+	 */
+	template<typename Signature, typename Guard>
+	class guarded_function {
+	public:
+		typedef typename boost::function_types::result_type<Signature>::type result_type;
+
+		template<typename Fn>
+		explicit guarded_function(Fn fn)
+				: fn_(fn) {}
+
+		result_type operator()() {
+			Guard g;
+			return fn_();
+		}
+
+		template<typename A1>
+		result_type operator()(const A1 &a1) {
+			Guard g;
+			return fn_(a1);
+		}
+
+		template<typename A1, typename A2>
+		result_type operator()(const A1 &a1, const A2 &a2) {
+			Guard g;
+			return fn_(a1, a2);
+		}
+
+		template<typename A1, typename A2, typename A3>
+		result_type operator()(const A1 &a1, const A2 &a2, const A3 &a3) {
+			Guard g;
+			return fn_(a1, a2, a3);
+		}
+
+	private:
+		boost::function<Signature> fn_;
+	};
+
+	/** Provides signature type. */
+	template<typename Signature>
+	struct mpl_signature {
+		typedef typename boost::function_types::components<Signature,
+				boost::add_pointer<boost::mpl::placeholders::_> >::type type;
+	};
+
+	/** Support boost::function. */
+	template<typename Signature>
+	struct mpl_signature<boost::function<Signature> > {
+		typedef typename boost::function_types::components<Signature>::type type;
+	};
+
+	/** Create a callable object with guards. */
+	template<typename Guard, typename Fn, typename Policy>
+	boost::python::object with_aux(Fn fn, const Policy &policy) {
+		// Obtain the components of the Fn.  This will decompose non-member
+		// and member functions into an mpl sequence.
+		//   R (*)(A1)    => R, A1
+		//   R (C::*)(A1) => R, C*, A1
+		typedef typename mpl_signature<Fn>::type mpl_signature_type;
+
+		// Synthesize the components into a function type.  This process
+		// causes member functions to require the instance argument.
+		// This is necessary because member functions will be explicitly
+		// provided the 'self' argument.
+		//   R, A1     => R (*)(A1)
+		//   R, C*, A1 => R (*)(C*, A1)
+		typedef typename boost::function_types::function_type<
+				mpl_signature_type>::type signature_type;
+
+		// Create a callable boost::python::object that delegates to the
+		// guarded_function.
+		return boost::python::make_function(
+				guarded_function<signature_type, Guard>(fn),
+				policy, mpl_signature_type());
+	}
+
+	/** Create a callable object with guards. */
+	template<typename Guard, typename Fn, typename Policy>
+	boost::python::object with(const Fn &fn, const Policy &policy) {
+		return with_aux<Guard>(fn, policy);
+	}
+
+	/** @brief Create a callable object with guards. */
+	template<typename Guard, typename Fn>
+	boost::python::object with(const Fn &fn) {
+		return with<Guard>(fn, boost::python::default_call_policies());
+	}
+}
+
+#endif //KNOWROB_PY_WITH_H

--- a/jupyter/python-kb.ipynb
+++ b/jupyter/python-kb.ipynb
@@ -151,7 +151,7 @@
    },
    "outputs": [],
    "source": [
-    "resultStream = kb.submitQueryFormula(phi1, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
+    "resultStream = kb.submitQuery(phi1, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
     "resultQueue = resultStream.createQueue()\n",
     "# Get the result\n",
     "nextResult1 = resultQueue.pop_front()"
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "phi2 = QueryParser.parse(\"swrl_test:hasAncestor(swrl_test:'Lea', swrl_test:'Lea')\")\n",
-    "resultStream = kb.submitQueryFormula(phi2, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
+    "resultStream = kb.submitQuery(phi2, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
     "resultQueue = resultStream.createQueue()\n",
     "# Get the result\n",
     "nextResult2 = resultQueue.pop_front()\n",
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "phi3 = QueryParser.parse(\"r(?x, ?y)\")\n",
-    "resultStream = kb.submitQueryFormula(phi3, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
+    "resultStream = kb.submitQuery(phi3, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))\n",
     "resultQueue = resultStream.createQueue()\n",
     "# Get the result\n",
     "nextResult3 = resultQueue.pop_front()\n",

--- a/src/KnowledgeBase.cpp
+++ b/src/KnowledgeBase.cpp
@@ -20,6 +20,7 @@
 #include "knowrob/ontologies/GraphTransformation.h"
 #include "knowrob/ontologies/TransformedOntology.h"
 #include "knowrob/integration/python/utils.h"
+#include "knowrob/integration/python/with.h"
 
 #define KB_SETTING_REASONER "reasoner"
 #define KB_SETTING_DATA_BACKENDS "data-backends"
@@ -632,19 +633,19 @@ namespace knowrob::py {
 				.def("__init__", make_constructor(&makeKB1))
 				.def("__init__", make_constructor(&makeKB2))
 				.def("__init__", make_constructor(&makeKB3))
-				.def("loadCommon", &KnowledgeBase::loadCommon)
-				.def("loadDataSource", &KnowledgeBase::loadDataSource)
+				.def("setDefaultGraph", &KnowledgeBase::setDefaultGraph)
 				.def("vocabulary", &KnowledgeBase::vocabulary, return_value_policy<copy_const_reference>())
-				.def("submitQueryFormula", static_cast<QueryFormula>(&KnowledgeBase::submitQuery))
-				.def("submitQueryPredicate", static_cast<QueryPredicate>(&KnowledgeBase::submitQuery))
-				.def("submitQueryGraph", static_cast<QueryGraph>(&KnowledgeBase::submitQuery))
-				.def("insertOne", &KnowledgeBase::insertOne)
-				.def("insertAllFromContainer", static_cast<ContainerAction>(&KnowledgeBase::insertAll))
-				.def("insertAllFromList", static_cast<ListAction>(&KnowledgeBase::insertAll))
-				.def("removeOne", &KnowledgeBase::removeOne)
-				.def("removeAllFromContainer", static_cast<ContainerAction>(&KnowledgeBase::removeAll))
-				.def("removeAllFromList", static_cast<ListAction>(&KnowledgeBase::removeAll))
-				.def("removeAllWithOrigin", &KnowledgeBase::removeAllWithOrigin)
-				.def("setDefaultGraph", &KnowledgeBase::setDefaultGraph);
+				.def("loadCommon", with<no_gil>(&KnowledgeBase::loadCommon))
+				.def("loadDataSource", with<no_gil>(&KnowledgeBase::loadDataSource))
+				.def("submitQuery", with<no_gil>(static_cast<QueryFormula>(&KnowledgeBase::submitQuery)))
+				.def("submitQuery", with<no_gil>(static_cast<QueryPredicate>(&KnowledgeBase::submitQuery)))
+				.def("submitQuery", with<no_gil>(static_cast<QueryGraph>(&KnowledgeBase::submitQuery)))
+				.def("insertOne", with<no_gil>(&KnowledgeBase::insertOne))
+				.def("insertAll", with<no_gil>(static_cast<ContainerAction>(&KnowledgeBase::insertAll)))
+				.def("insertAll", with<no_gil>(static_cast<ListAction>(&KnowledgeBase::insertAll)))
+				.def("removeOne", with<no_gil>(&KnowledgeBase::removeOne))
+				.def("removeAll", with<no_gil>(static_cast<ContainerAction>(&KnowledgeBase::removeAll)))
+				.def("removeAll", with<no_gil>(static_cast<ListAction>(&KnowledgeBase::removeAll)))
+				.def("removeAllWithOrigin", with<no_gil>(&KnowledgeBase::removeAllWithOrigin));
 	}
 }

--- a/src/queries/TokenBuffer.cpp
+++ b/src/queries/TokenBuffer.cpp
@@ -60,7 +60,7 @@ namespace knowrob::py {
 		using namespace boost::python;
 		class_<TokenBuffer, std::shared_ptr<TokenBuffer>, bases<TokenBroadcaster>, boost::noncopyable>
 				("TokenBuffer", init<>())
-				.def("stopBuffering", &TokenBuffer::stopBuffering)
+				.def("stopBuffering", with<no_gil>(&TokenBuffer::stopBuffering))
 				.def("createQueue", &TokenBuffer::createQueue);
 	}
 }

--- a/src/queries/TokenQueue.cpp
+++ b/src/queries/TokenQueue.cpp
@@ -52,9 +52,9 @@ namespace knowrob::py {
 		using namespace boost::python;
 		class_<TokenQueue, std::shared_ptr<TokenQueue>, bases<TokenStream>, boost::noncopyable>
 				("TokenQueue", init<>())
-				.def("front", &TokenQueue::front, return_value_policy<reference_existing_object>())
+				.def("front", with<no_gil>(&TokenQueue::front, return_value_policy<reference_existing_object>()))
 				.def("pop", &TokenQueue::pop)
-				.def("pop_front", &TokenQueue::pop_front)
+				.def("pop_front", with<no_gil>(&TokenQueue::pop_front))
 				.def("empty", &TokenQueue::empty)
 				.def("size", &TokenQueue::size);
 	}

--- a/src/queries/TokenStream.cpp
+++ b/src/queries/TokenStream.cpp
@@ -148,8 +148,8 @@ namespace knowrob::py {
 		class_<TokenStream::Channel, std::shared_ptr<TokenStream::Channel>, boost::noncopyable>
 				("TokenChannel", no_init)
 				.def("create", &TokenStream::Channel::create).staticmethod("create")
-				.def("push", &TokenStream::Channel::push)
-				.def("close", &TokenStream::Channel::close)
+				.def("push", with<no_gil>(&TokenStream::Channel::push))
+				.def("close", with<no_gil>(&TokenStream::Channel::close))
 				.def("isOpened", &TokenStream::Channel::isOpened)
 				.def("id", &TokenStream::Channel::id);
 		createType<TokenQueue>();

--- a/tests/py/test_boost_python.py
+++ b/tests/py/test_boost_python.py
@@ -24,7 +24,7 @@ def perform_query(settings_path, query_string,):
 	# Apply the modality
 	mPhi = InterfaceUtils.applyModality(modalities, phi)
 	# Get Result Stream
-	resultStream = kb.submitQueryFormula(mPhi, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))
+	resultStream = kb.submitQuery(mPhi, QueryContext(QueryFlag.QUERY_FLAG_ALL_SOLUTIONS))
 	resultQueue = resultStream.createQueue()
 	# Get the result
 	nextResult = resultQueue.pop_front()


### PR DESCRIPTION
- added `with<no_gil>` decorator to some methods
- it seems boost python actually allows to export the same function with different signatures! So this PR also unifies Python and C++ API a bit