### PR TITLE
work on taxonomy data update in mongo

### DIFF
--- a/include/knowrob/semweb/Class.h
+++ b/include/knowrob/semweb/Class.h
@@ -17,11 +17,13 @@ namespace knowrob::semweb {
 
 	// called for each parent in the property hierarchy
 	using ClassVisitor = std::function<void(Class &)>;
+	// called for each parent in the property hierarchy
+	using ClassTupleVisitor = std::function<void(Class &, Class &)>;
 
 	/**
 	 * A RDF class.
 	 */
-	class Class : public Resource {
+	class Class : public Resource, public std::enable_shared_from_this<Class> {
 	public:
 		/**
 		 * @param iri A class IRI.
@@ -68,6 +70,13 @@ namespace knowrob::semweb {
 		 */
 		void forallParents(const ClassVisitor &visitor, bool includeSelf = true, bool skipDuplicates = true);
 
+		/**
+		 * @param visitor a function that is called for each child in the class hierarchy.
+		 * @param includeSelf if true, the method calls the visitor for this class.
+		 * @param skipDuplicates if true, the method calls the visitor only once for each class.
+		 */
+		void forallChildren(const ClassTupleVisitor &visitor, bool skipDuplicates = true);
+
 	protected:
 		struct ClassComparator {
 			bool operator()(const std::shared_ptr<Class> &lhs, const std::shared_ptr<Class> &rhs) const;
@@ -76,6 +85,7 @@ namespace knowrob::semweb {
 		std::map<std::shared_ptr<Class>,
 				std::set<AtomPtr, AtomComparator>,
 				ClassComparator> directParents_;
+		std::set<std::shared_ptr<Class>, ClassComparator> directChildren_;
 	};
 
 	using ClassPtr = std::shared_ptr<Class>;

--- a/include/knowrob/semweb/Class.h
+++ b/include/knowrob/semweb/Class.h
@@ -36,12 +36,12 @@ namespace knowrob::semweb {
 		/**
 		 * @param directParent a direct super class.
 		 */
-		void addDirectParent(const std::shared_ptr<Class> &directParent);
+		void addDirectParent(const std::shared_ptr<Class> &directParent, std::optional<std::string_view> graph);
 
 		/**
 		 * @param directParent a direct super class.
 		 */
-		void removeDirectParent(const std::shared_ptr<Class> &directParent);
+		void removeDirectParent(const std::shared_ptr<Class> &directParent, std::optional<std::string_view> graph);
 
 		/**
 		 * @return all direct super classes of this class.
@@ -69,10 +69,13 @@ namespace knowrob::semweb {
 		void forallParents(const ClassVisitor &visitor, bool includeSelf = true, bool skipDuplicates = true);
 
 	protected:
-		struct Comparator {
+		struct ClassComparator {
 			bool operator()(const std::shared_ptr<Class> &lhs, const std::shared_ptr<Class> &rhs) const;
 		};
-		std::set<std::shared_ptr<Class>, Comparator> directParents_;
+
+		std::map<std::shared_ptr<Class>,
+				std::set<AtomPtr, AtomComparator>,
+				ClassComparator> directParents_;
 	};
 
 	using ClassPtr = std::shared_ptr<Class>;

--- a/include/knowrob/semweb/Property.h
+++ b/include/knowrob/semweb/Property.h
@@ -31,11 +31,13 @@ namespace knowrob::semweb {
 
 	// called for each parent in the property hierarchy
 	using PropertyVisitor = std::function<void(Property &)>;
+	// called for each parent in the property hierarchy
+	using PropertyTupleVisitor = std::function<void(Property &, Property &)>;
 
 	/**
 	 * A property used in knowledge graphs.
 	 */
-	class Property : public Resource {
+	class Property : public Resource, public std::enable_shared_from_this<Property> {
 	public:
 		explicit Property(std::string_view iri);
 
@@ -118,6 +120,13 @@ namespace knowrob::semweb {
 		void forallParents(const PropertyVisitor &visitor, bool includeSelf = true, bool skipDuplicates = true);
 
 		/**
+		 * @param visitor a function that is called for each child in the class hierarchy.
+		 * @param includeSelf if true, the method calls the visitor for this class.
+		 * @param skipDuplicates if true, the method calls the visitor only once for each class.
+		 */
+		void forallChildren(const PropertyTupleVisitor &visitor, bool skipDuplicates = true);
+
+		/**
 		 * @return the reification concept of this property.
 		 */
 		auto reification() const { return reification_; }
@@ -145,6 +154,7 @@ namespace knowrob::semweb {
 		std::map<std::shared_ptr<Property>,
 				std::set<AtomPtr, AtomComparator>,
 				PropertyComparator> directParents_;
+		std::set<std::shared_ptr<Property>, PropertyComparator> directChildren_;
 		std::shared_ptr<Class> reification_;
 		int flags_;
 	};

--- a/include/knowrob/semweb/Property.h
+++ b/include/knowrob/semweb/Property.h
@@ -44,12 +44,12 @@ namespace knowrob::semweb {
 		/**
 		 * @param directParent a direct super property.
 		 */
-		void addDirectParent(const std::shared_ptr<Property> &directParent);
+		void addDirectParent(const std::shared_ptr<Property> &directParent, std::optional<std::string_view> graph);
 
 		/**
 		 * @param directParent a direct super property.
 		 */
-		void removeDirectParent(const std::shared_ptr<Property> &directParent);
+		void removeDirectParent(const std::shared_ptr<Property> &directParent, std::optional<std::string_view> graph);
 
 		/**
 		 * @return all direct super properties of this property.
@@ -137,12 +137,14 @@ namespace knowrob::semweb {
 		static knowrob::IRIAtomPtr unReifiedIRI(std::string_view iri);
 
 	protected:
-		struct Comparator {
+		struct PropertyComparator {
 			bool operator()(const std::shared_ptr<Property> &lhs, const std::shared_ptr<Property> &rhs) const;
 		};
 
 		std::shared_ptr<Property> inverse_;
-		std::set<std::shared_ptr<Property>, Comparator> directParents_;
+		std::map<std::shared_ptr<Property>,
+				std::set<AtomPtr, AtomComparator>,
+				PropertyComparator> directParents_;
 		std::shared_ptr<Class> reification_;
 		int flags_;
 	};

--- a/include/knowrob/semweb/Resource.h
+++ b/include/knowrob/semweb/Resource.h
@@ -38,7 +38,7 @@ namespace knowrob::semweb {
 		/**
 		 * @return the namespace of this resource.
 		 */
-		std::string_view ns(bool includeDelimiter=false) const;
+		std::string_view ns(bool includeDelimiter = false) const;
 
 		/**
 		 * Generate a unique IRI for a resource.
@@ -66,10 +66,21 @@ namespace knowrob::semweb {
 		 * @param includeDelimiter if true, the delimiter is included in the result
 		 * @return the namespace part of the IRI
 		 */
-		static std::string_view iri_ns(std::string_view iri, bool includeDelimiter=false);
+		static std::string_view iri_ns(std::string_view iri, bool includeDelimiter = false);
+
+		/**
+		 * Obtain an atom from an optional string.
+		 * @param graph an optional string
+		 * @return an atom
+		 */
+		static AtomPtr graph_atom(std::optional<std::string_view> graph);
 
 	protected:
 		knowrob::AtomPtr iri_;
+
+		struct AtomComparator {
+			bool operator()(const AtomPtr &lhs, const AtomPtr &rhs) const;
+		};
 	};
 
 } // knowrob::semweb

--- a/include/knowrob/semweb/Vocabulary.h
+++ b/include/knowrob/semweb/Vocabulary.h
@@ -67,7 +67,8 @@ namespace knowrob {
 		 * @param subClass a IRI
 		 * @param superClass a IRI
 		 */
-		void addSubClassOf(const std::string_view &subClass, const std::string_view &superClass);
+		void addSubClassOf(const std::string_view &subClass, const std::string_view &superClass,
+						   std::optional<std::string_view> graph);
 
 		/**
 		 * @param subClass a IRI
@@ -132,7 +133,8 @@ namespace knowrob {
 		 * @param subProperty a IRI
 		 * @param superProperty a IRI
 		 */
-		void addSubPropertyOf(const std::string_view &subProperty, const std::string_view &superProperty);
+		void addSubPropertyOf(const std::string_view &subProperty, const std::string_view &superProperty,
+							  std::optional<std::string_view> graph);
 
 		/**
 		 * Define inverseOf relation between properties.

--- a/include/knowrob/semweb/Vocabulary.h
+++ b/include/knowrob/semweb/Vocabulary.h
@@ -207,6 +207,15 @@ namespace knowrob {
 		 */
 		const std::shared_ptr<ImportHierarchy> &importHierarchy() const { return importHierarchy_; }
 
+		/**
+		 * Define a new class if it has not been defined before.
+		 * @tparam T the resource type (either Class or Property)
+		 * @param iri a IRI
+		 * @return the resource defined for the IRI
+		 */
+		template<typename T>
+		std::shared_ptr<T> define(const std::string_view &iri);
+
 	protected:
 		std::map<std::string_view, semweb::ClassPtr, std::less<>> definedClasses_;
 		std::map<std::string_view, semweb::PropertyPtr, std::less<>> definedProperties_;

--- a/include/knowrob/storage/mongo/BulkOperation.h
+++ b/include/knowrob/storage/mongo/BulkOperation.h
@@ -58,8 +58,14 @@ namespace knowrob::mongo {
 		 */
 		void execute();
 
+		/**
+		 * @return true if this bulk operation is empty.
+		 */
+		bool empty() const { return empty_; }
+
 	protected:
 		mongoc_bulk_operation_t *handle_;
+		bool empty_ = true;
 
 		void validateBulkHandle();
 	};

--- a/include/knowrob/storage/mongo/MongoTaxonomy.h
+++ b/include/knowrob/storage/mongo/MongoTaxonomy.h
@@ -24,7 +24,11 @@ namespace knowrob::mongo {
 					  const std::shared_ptr<mongo::Collection> &oneCollection,
 					  const VocabularyPtr &vocabulary);
 
-		void update(
+		void updateInsert(
+				const std::vector<StringPair> &subClassAssertions,
+				const std::vector<StringPair> &subPropertyAssertions);
+
+		void updateRemove(
 				const std::vector<StringPair> &subClassAssertions,
 				const std::vector<StringPair> &subPropertyAssertions);
 
@@ -32,6 +36,11 @@ namespace knowrob::mongo {
 		std::shared_ptr<mongo::Collection> tripleCollection_;
 		std::shared_ptr<mongo::Collection> oneCollection_;
 		VocabularyPtr vocabulary_;
+
+		void update(
+				const std::vector<StringPair> &subClassAssertions,
+				const std::vector<StringPair> &subPropertyAssertions,
+				bool isInsert);
 	};
 
 } // knowrob

--- a/include/knowrob/storage/mongo/MongoTaxonomy.h
+++ b/include/knowrob/storage/mongo/MongoTaxonomy.h
@@ -32,18 +32,6 @@ namespace knowrob::mongo {
 		std::shared_ptr<mongo::Collection> tripleCollection_;
 		std::shared_ptr<mongo::Collection> oneCollection_;
 		VocabularyPtr vocabulary_;
-
-		static void lookupParents(
-				mongo::Pipeline &pipeline,
-				const std::string_view &collectionName,
-				const std::string_view &entity,
-				const std::string_view &hierarchyRelation);
-
-		static void updateHierarchyP(
-				mongo::Pipeline &pipeline,
-				const std::string_view &collection,
-				const std::string_view &relation,
-				const std::string_view &newChild);
 	};
 
 } // knowrob

--- a/include/knowrob/storage/mongo/MongoTaxonomy.h
+++ b/include/knowrob/storage/mongo/MongoTaxonomy.h
@@ -21,7 +21,8 @@ namespace knowrob::mongo {
 		using StringPair = std::pair<std::string_view, std::string_view>;
 
 		MongoTaxonomy(const std::shared_ptr<mongo::Collection> &tripleCollection,
-					  const std::shared_ptr<mongo::Collection> &oneCollection);
+					  const std::shared_ptr<mongo::Collection> &oneCollection,
+					  const VocabularyPtr &vocabulary);
 
 		void update(
 				const std::vector<StringPair> &subClassAssertions,
@@ -30,6 +31,7 @@ namespace knowrob::mongo {
 	protected:
 		std::shared_ptr<mongo::Collection> tripleCollection_;
 		std::shared_ptr<mongo::Collection> oneCollection_;
+		VocabularyPtr vocabulary_;
 
 		static void lookupParents(
 				mongo::Pipeline &pipeline,
@@ -42,13 +44,6 @@ namespace knowrob::mongo {
 				const std::string_view &collection,
 				const std::string_view &relation,
 				const std::string_view &newChild);
-
-		static void updateHierarchyO(
-				mongo::Pipeline &pipeline,
-				const std::string_view &collectionName,
-				const std::string_view &relation,
-				const std::string_view &newChild,
-				const std::string_view &newParent);
 	};
 
 } // knowrob

--- a/src/KnowledgeBase.cpp
+++ b/src/KnowledgeBase.cpp
@@ -205,13 +205,13 @@ void KnowledgeBase::initVocabulary() {
 		// iterate over all rdfs::subClassOf assertions and add them to the vocabulary
 		backend->match(FramedTriplePattern(v_s, rdfs::subClassOf, v_o),
 					   [this](const FramedTriplePtr &triple) {
-						   vocabulary_->addSubClassOf(triple->subject(), triple->valueAsString());
+						   vocabulary_->addSubClassOf(triple->subject(), triple->valueAsString(), triple->graph());
 						   vocabulary_->increaseFrequency(rdfs::subClassOf->stringForm());
 					   });
 		// iterate over all rdfs::subPropertyOf assertions and add them to the vocabulary
 		backend->match(FramedTriplePattern(v_s, rdfs::subPropertyOf, v_o),
 					   [this](const FramedTriplePtr &triple) {
-						   vocabulary_->addSubPropertyOf(triple->subject(), triple->valueAsString());
+						   vocabulary_->addSubPropertyOf(triple->subject(), triple->valueAsString(), triple->graph());
 						   vocabulary_->increaseFrequency(rdfs::subPropertyOf->stringForm());
 					   });
 		// iterate over all owl::inverseOf assertions and add them to the vocabulary

--- a/src/semweb/Property.cpp
+++ b/src/semweb/Property.cpp
@@ -69,6 +69,7 @@ void Property::addDirectParent(const std::shared_ptr<Property> &directParent, st
 	} else {
 		// add new entry
 		directParents_[directParent].insert(graphAtom);
+		directParent->directChildren_.insert(shared_from_this());
 	}
 	reification_->addDirectParent(directParent->reification_, graph);
 }
@@ -88,6 +89,7 @@ Property::removeDirectParent(const std::shared_ptr<Property> &directParent, std:
 		// remove if no origin is left
 		if (pair->second.empty()) {
 			directParents_.erase(pair);
+			directParent->directChildren_.erase(shared_from_this());
 			reification_->removeDirectParent(directParent->reification_, graph);
 		}
 	}
@@ -127,6 +129,31 @@ void Property::forallParents(const PropertyVisitor &visitor,
 		for (auto &directParent: front->directParents_) {
 			if (skipDuplicates && visited_.count(directParent.first->iri()) > 0) continue;
 			queue_.push(directParent.first.get());
+		}
+	}
+}
+
+void Property::forallChildren(const PropertyTupleVisitor &visitor, bool skipDuplicates) {
+	std::queue<std::pair<Property *, Property *>> queue_;
+	std::set<std::string_view> visited_;
+
+	// push initial elements to the queue
+	for (auto &x: directChildren_) queue_.emplace(x.get(), this);
+
+	// visit each child
+	while (!queue_.empty()) {
+		auto pair = queue_.front();
+		auto front_child = pair.first;
+		auto front_parent = pair.second;
+		queue_.pop();
+		// visit popped property
+		visitor(*front_child, *front_parent);
+		// remember visited nodes
+		if (skipDuplicates) visited_.insert(front_child->iri());
+		// push children of visited property on the queue
+		for (auto &directChild: front_child->directChildren_) {
+			if (skipDuplicates && visited_.count(directChild->iri()) > 0) continue;
+			queue_.emplace(directChild.get(), front_child);
 		}
 	}
 }

--- a/src/semweb/Resource.cpp
+++ b/src/semweb/Resource.cpp
@@ -12,8 +12,13 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <iomanip>
 #include "knowrob/integration/python/utils.h"
+#include "knowrob/semweb/ImportHierarchy.h"
 
 using namespace knowrob::semweb;
+
+bool Resource::AtomComparator::operator()(const AtomPtr &lhs, const AtomPtr &rhs) const {
+	return lhs->stringForm() < rhs->stringForm();
+}
 
 Resource::Resource(std::string_view iri) {
 	switch (rdfNodeTypeGuess(iri)) {
@@ -74,13 +79,17 @@ std::string_view Resource::ns(bool includeDelimiter) const {
 	return iri_ns(iri_->stringForm(), includeDelimiter);
 }
 
+knowrob::AtomPtr Resource::graph_atom(std::optional<std::string_view> graph) {
+	return graph ? IRIAtom::Tabled(graph.value()) : IRIAtom::Tabled(ImportHierarchy::ORIGIN_SESSION);
+}
+
 namespace knowrob::py {
 	template<>
 	void createType<semweb::Resource>() {
 		using namespace boost::python;
 
 		using IRIArg1 = IRIAtomPtr (*)(std::string_view);
-		using IRIArg2 = IRIAtomPtr (*)(std::string_view,std::string_view);
+		using IRIArg2 = IRIAtomPtr (*)(std::string_view, std::string_view);
 
 		class_<semweb::Resource, std::shared_ptr<semweb::Resource>, boost::noncopyable>
 				("Resource", no_init)

--- a/src/semweb/Vocabulary.cpp
+++ b/src/semweb/Vocabulary.cpp
@@ -246,6 +246,16 @@ void Vocabulary::addResourceType(const std::string_view &resource_iri, const std
 		defineClass(resource_iri);
 }
 
+namespace knowrob {
+	template<>
+	std::shared_ptr<semweb::Class>
+	Vocabulary::define<semweb::Class>(const std::string_view &iri) { return defineClass(iri); }
+
+	template<>
+	std::shared_ptr<semweb::Property>
+	Vocabulary::define<semweb::Property>(const std::string_view &iri) { return defineProperty(iri); }
+}
+
 namespace knowrob::py {
 	template<>
 	void createType<Vocabulary>() {

--- a/src/semweb/Vocabulary.cpp
+++ b/src/semweb/Vocabulary.cpp
@@ -16,7 +16,7 @@ using namespace knowrob;
 using namespace knowrob::semweb;
 
 Vocabulary::Vocabulary()
-	: importHierarchy_(std::make_shared<ImportHierarchy>()) {
+		: importHierarchy_(std::make_shared<ImportHierarchy>()) {
 	setPropertyFlag(rdfs::comment, ANNOTATION_PROPERTY);
 	setPropertyFlag(rdfs::seeAlso, ANNOTATION_PROPERTY);
 	setPropertyFlag(rdfs::label, ANNOTATION_PROPERTY);
@@ -70,8 +70,9 @@ ClassPtr Vocabulary::defineClass(const std::string_view &iri) {
 	}
 }
 
-void Vocabulary::addSubClassOf(const std::string_view &subClass, const std::string_view &superClass) {
-	defineClass(subClass)->addDirectParent(defineClass(superClass));
+void Vocabulary::addSubClassOf(const std::string_view &subClass, const std::string_view &superClass,
+							   std::optional<std::string_view> graph) {
+	defineClass(subClass)->addDirectParent(defineClass(superClass), graph);
 }
 
 bool Vocabulary::isSubClassOf(const std::string_view &subClass, const std::string_view &superClass) {
@@ -147,7 +148,8 @@ semweb::PropertyPtr Vocabulary::defineProperty_(const std::shared_ptr<Property> 
 	// note further superclasses will be added through Property::addDirectParent
 	auto reification = p->reification();
 	definedClasses_[reification->iri()] = reification;
-	reification->addDirectParent(defineClass(reification::ReifiedRelation->stringForm()));
+	reification->addDirectParent(defineClass(reification::ReifiedRelation->stringForm()),
+								 ImportHierarchy::ORIGIN_SYSTEM);
 	return p;
 }
 
@@ -159,8 +161,9 @@ void Vocabulary::setPropertyFlag(const IRIAtomPtr &iri, PropertyFlag flag) {
 	defineProperty(iri)->setFlag(flag);
 }
 
-void Vocabulary::addSubPropertyOf(const std::string_view &subProperty, const std::string_view &superProperty) {
-	defineProperty(subProperty)->addDirectParent(defineProperty(superProperty));
+void Vocabulary::addSubPropertyOf(const std::string_view &subProperty, const std::string_view &superProperty,
+								  std::optional<std::string_view> graph) {
+	defineProperty(subProperty)->addDirectParent(defineProperty(superProperty), graph);
 }
 
 void Vocabulary::setInverseOf(const std::string_view &a, const std::string_view &b) {
@@ -248,8 +251,8 @@ namespace knowrob::py {
 	void createType<Vocabulary>() {
 		using namespace boost::python;
 
-		using PropertyFun = semweb::PropertyPtr (Vocabulary::*)(const std::string_view&);
-		using SetFlag = void (Vocabulary::*)(const std::string_view&, semweb::PropertyFlag);
+		using PropertyFun = semweb::PropertyPtr (Vocabulary::*)(const std::string_view &);
+		using SetFlag = void (Vocabulary::*)(const std::string_view &, semweb::PropertyFlag);
 
 		createType<semweb::Resource>();
 		createType<semweb::Property>();

--- a/src/storage/Transaction.cpp
+++ b/src/storage/Transaction.cpp
@@ -199,12 +199,12 @@ void Insert::updateVocabulary(const FramedTriple &triple) {
 	if (isSubClassOfIRI(triple.predicate())) {
 		auto sub = vocabulary_->defineClass(triple.subject());
 		auto sup = vocabulary_->defineClass(triple.valueAsString());
-		sub->addDirectParent(sup);
+		sub->addDirectParent(sup, triple.graph());
 		vocabulary_->increaseFrequency(rdfs::subClassOf->stringForm());
 	} else if (isSubPropertyOfIRI(triple.predicate())) {
 		auto sub = vocabulary_->defineProperty(triple.subject());
 		auto sup = vocabulary_->defineProperty(triple.valueAsString());
-		sub->addDirectParent(sup);
+		sub->addDirectParent(sup, triple.graph());
 		vocabulary_->increaseFrequency(rdfs::subPropertyOf->stringForm());
 	} else if (isTypeIRI(triple.predicate())) {
 		vocabulary_->addResourceType(triple.subject(), triple.valueAsString());
@@ -246,19 +246,14 @@ void Insert::updateVocabulary(const FramedTriple &triple) {
 }
 
 void Remove::updateVocabulary(const FramedTriple &triple) {
-	// TODO: a triple can have multiple origins, so updating the vocabulary on removal is not safe without
-	//  knowing if the triple has other origins. But (1) there is no interface yet to query for the origins of
-	//  a triple, and (2) maybe it can be avoided to do additional querying here.
-#if 0
 	// remove subclass and subproperty relations from the vocabulary.
 	if (isSubClassOfIRI(triple.predicate())) {
 		auto sub = vocabulary_->defineClass(triple.subject());
 		auto sup = vocabulary_->defineClass(triple.valueAsString());
-		sub->removeDirectParent(sup);
+		sub->removeDirectParent(sup, triple.graph());
 	} else if (isSubPropertyOfIRI(triple.predicate())) {
 		auto sub = vocabulary_->defineProperty(triple.subject());
 		auto sup = vocabulary_->defineProperty(triple.valueAsString());
-		sub->removeDirectParent(sup);
+		sub->removeDirectParent(sup, triple.graph());
 	}
-#endif
 }

--- a/src/storage/mongo/BulkOperation.cpp
+++ b/src/storage/mongo/BulkOperation.cpp
@@ -41,6 +41,7 @@ void BulkOperation::pushInsert(const bson_t *document) {
 			&err)) {
 		throw MongoException("bulk_operation", err);
 	}
+	empty_ = false;
 }
 
 void BulkOperation::pushRemoveOne(const bson_t *document) {
@@ -54,6 +55,7 @@ void BulkOperation::pushRemoveOne(const bson_t *document) {
 			&err)) {
 		throw MongoException("bulk_operation", err);
 	}
+	empty_ = false;
 }
 
 void BulkOperation::pushRemoveAll(const bson_t *document) {
@@ -67,6 +69,7 @@ void BulkOperation::pushRemoveAll(const bson_t *document) {
 			&err)) {
 		throw MongoException("bulk_operation", err);
 	}
+	empty_ = false;
 }
 
 void BulkOperation::pushUpdate(bson_t *query, bson_t *update) {
@@ -81,6 +84,7 @@ void BulkOperation::pushUpdate(bson_t *query, bson_t *update) {
 			&err)) {
 		throw MongoException("bulk_operation", err);
 	}
+	empty_ = false;
 }
 
 

--- a/src/storage/mongo/MongoKnowledgeGraph.cpp
+++ b/src/storage/mongo/MongoKnowledgeGraph.cpp
@@ -59,7 +59,7 @@ MongoKnowledgeGraph::MongoKnowledgeGraph()
 }
 
 MongoKnowledgeGraph::ConnectionRAII::ConnectionRAII(const MongoKnowledgeGraph *kg)
-	: kg(kg), mongo(kg->acquireStore()) {}
+		: kg(kg), mongo(kg->acquireStore()) {}
 
 MongoKnowledgeGraph::ConnectionRAII::~ConnectionRAII() {
 	kg->releaseStore(mongo);
@@ -76,7 +76,7 @@ mongo::TripleStore MongoKnowledgeGraph::acquireStore() const {
 				tripleCollection->connection(),
 				tripleCollection->dbName().c_str(),
 				MONGO_KG_ONE_COLLECTION);
-		return { tripleCollection, oneCollection, vocabulary_ };
+		return {tripleCollection, oneCollection, vocabulary_};
 	} else {
 		auto store = connections_.front();
 		connections_.pop_front();
@@ -161,7 +161,7 @@ void MongoKnowledgeGraph::initializeMongo(const std::shared_ptr<mongo::Collectio
 		oneCollection_->storeOne(oneDoc);
 	}
 	// Create an object used for taxonomy operations
-	taxonomy_ = std::make_shared<MongoTaxonomy>(tripleCollection_, oneCollection_);
+	taxonomy_ = std::make_shared<MongoTaxonomy>(tripleCollection_, oneCollection_, vocabulary_);
 	// Add the connection to connection list
 	connections_.emplace_back(tripleCollection_, oneCollection_, vocabulary_);
 }
@@ -351,7 +351,8 @@ void MongoKnowledgeGraph::foreach(const TripleVisitor &visitor) const {
 	iterate(cursor, visitor);
 }
 
-static void batch_(const std::shared_ptr<mongo::Collection> &collection, const TripleHandler &callback, bson_t *filter) {
+static void
+batch_(const std::shared_ptr<mongo::Collection> &collection, const TripleHandler &callback, bson_t *filter) {
 	TripleCursor cursor(collection);
 	if (filter) {
 		cursor.filter(filter);

--- a/src/storage/mongo/MongoKnowledgeGraph.cpp
+++ b/src/storage/mongo/MongoKnowledgeGraph.cpp
@@ -229,9 +229,9 @@ bool MongoKnowledgeGraph::insertOne(const FramedTriple &tripleData) {
 	scoped.mongo.tripleCollection->storeOne(mngTriple.document());
 
 	if (isSubClassOfIRI(tripleData.predicate())) {
-		taxonomy_->update({{tripleData.subject(), tripleData.valueAsString()}}, {});
+		taxonomy_->updateInsert({{tripleData.subject(), tripleData.valueAsString()}}, {});
 	} else if (isSubPropertyOfIRI(tripleData.predicate())) {
-		taxonomy_->update({}, {{tripleData.subject(), tripleData.valueAsString()}});
+		taxonomy_->updateInsert({}, {{tripleData.subject(), tripleData.valueAsString()}});
 	}
 
 	return true;
@@ -242,10 +242,8 @@ bool MongoKnowledgeGraph::insertAll(const TripleContainerPtr &triples) {
 	// only used in case triples do not specify origin field
 	auto &fallbackOrigin = vocabulary_->importHierarchy()->defaultGraph();
 	auto bulk = scoped.mongo.tripleCollection->createBulkOperation();
-	struct TaxonomyAssertions {
-		std::vector<MongoTaxonomy::StringPair> subClassAssertions;
-		std::vector<MongoTaxonomy::StringPair> subPropertyAssertions;
-	} tAssertions;
+	std::vector<MongoTaxonomy::StringPair> subClassAssertions;
+	std::vector<MongoTaxonomy::StringPair> subPropertyAssertions;
 
 	std::for_each(triples->begin(), triples->end(),
 				  [&](auto &data) {
@@ -254,14 +252,14 @@ bool MongoKnowledgeGraph::insertAll(const TripleContainerPtr &triples) {
 					  bulk->pushInsert(mngTriple.document().bson());
 
 					  if (isSubClassOfIRI(data->predicate())) {
-						  tAssertions.subClassAssertions.emplace_back(data->subject(), data->valueAsString());
+						  subClassAssertions.emplace_back(data->subject(), data->valueAsString());
 					  } else if (isSubPropertyOfIRI(data->predicate())) {
-						  tAssertions.subPropertyAssertions.emplace_back(data->subject(), data->valueAsString());
+						  subPropertyAssertions.emplace_back(data->subject(), data->valueAsString());
 					  }
 				  });
 	bulk->execute();
 
-	taxonomy_->update(tAssertions.subClassAssertions, tAssertions.subPropertyAssertions);
+	taxonomy_->updateInsert(subClassAssertions, subPropertyAssertions);
 
 	return true;
 }
@@ -273,12 +271,22 @@ bool MongoKnowledgeGraph::removeOne(const FramedTriple &triple) {
 			vocabulary_->isTaxonomicProperty(triple.predicate()),
 			vocabulary_->importHierarchy());
 	scoped.mongo.tripleCollection->removeOne(mngQuery.document());
+
+	if (isSubClassOfIRI(triple.predicate())) {
+		taxonomy_->updateRemove({{triple.subject(), triple.valueAsString()}}, {});
+	} else if (isSubPropertyOfIRI(triple.predicate())) {
+		taxonomy_->updateRemove({}, {{triple.subject(), triple.valueAsString()}});
+	}
+
 	return true;
 }
 
 bool MongoKnowledgeGraph::removeAll(const TripleContainerPtr &triples) {
 	ConnectionRAII scoped(this);
 	auto bulk = scoped.mongo.tripleCollection->createBulkOperation();
+	std::vector<MongoTaxonomy::StringPair> subClassAssertions;
+	std::vector<MongoTaxonomy::StringPair> subPropertyAssertions;
+
 	std::for_each(triples->begin(), triples->end(),
 				  [&](auto &data) {
 					  MongoTriplePattern mngQuery(
@@ -286,12 +294,16 @@ bool MongoKnowledgeGraph::removeAll(const TripleContainerPtr &triples) {
 					  vocabulary_->isTaxonomicProperty(data->predicate()),
 							  vocabulary_->importHierarchy());
 					  bulk->pushRemoveOne(mngQuery.bson());
+
+					  if (isSubClassOfIRI(data->predicate())) {
+						  subClassAssertions.emplace_back(data->subject(), data->valueAsString());
+					  } else if (isSubPropertyOfIRI(data->predicate())) {
+						  subPropertyAssertions.emplace_back(data->subject(), data->valueAsString());
+					  }
 				  });
 	bulk->execute();
 
-	// TODO: Update documents when "taxonomic" triples are removed.
-	//       In this case, some documents may need to be updated as the class hierarchy
-	//       may have changed, and is stored in the documents.
+	taxonomy_->updateRemove(subClassAssertions, subPropertyAssertions);
 
 	return true;
 }


### PR DESCRIPTION
- this PR addresses a long lasting todo in the code to improve the updating of taxonomy data in mongo. before a series of pipelines was executed. this PR performs the update in bulk operations instead which should be much more efficient. to this end a few changes to `semweb::Vocabulary` and related classes was needed.
- a second problem addressed by this PR is removal of taxonomic data. to this end the KB must keep track of origins to avoid deletion even though an assertion still has an origin