### PR TITLE
Fix minor problem in ReasonerManager

### DIFF
--- a/src/reasoner/ReasonerManager.cpp
+++ b/src/reasoner/ReasonerManager.cpp
@@ -53,8 +53,8 @@ std::vector<DefiningReasoner> ReasonerManager::findDefiningReasoner(const Predic
 		if (rdfClass) {
 			for (auto &x: goalDriven_) {
 				for (auto &definedClassIndicator : x.second->definedClasses()) {
-					if(kb_->vocabulary()->defineClass(definedClassIndicator.functor()->stringForm())) {
-						auto definedClass = kb_->vocabulary()->defineClass(definedClassIndicator.functor()->stringForm());
+					auto definedClass = kb_->vocabulary()->getDefinedClass(definedClassIndicator.functor()->stringForm());
+					if(definedClass && definedClass->isSubClassOf(rdfClass)) {
 						reasoners.push_back({x.second, definedClass->iriAtom()});
 						break;
 					}
@@ -71,8 +71,8 @@ std::vector<DefiningReasoner> ReasonerManager::findDefiningReasoner(const Predic
 		if (rdfProperty) {
 			for (auto &x: goalDriven_) {
 				for (auto &definedPropertyIndicator : x.second->definedRelations()) {
-                    if ( kb_->vocabulary()->isDefinedProperty(definedPropertyIndicator.functor()->stringForm())) { 
-                    	auto definedProperty = kb_->vocabulary()->defineProperty(definedPropertyIndicator.functor()->stringForm());
+					auto definedProperty = kb_->vocabulary()->getDefinedProperty(definedPropertyIndicator.functor()->stringForm());
+                    if ( definedProperty && definedProperty->isSubPropertyOf(rdfProperty) ) {
 						reasoners.push_back({x.second, definedProperty->iriAtom()});
 						break;
 					}

--- a/src/reasoner/ReasonerManager.cpp
+++ b/src/reasoner/ReasonerManager.cpp
@@ -53,8 +53,8 @@ std::vector<DefiningReasoner> ReasonerManager::findDefiningReasoner(const Predic
 		if (rdfClass) {
 			for (auto &x: goalDriven_) {
 				for (auto &definedClassIndicator : x.second->definedClasses()) {
-					auto definedClass = kb_->vocabulary()->defineClass(definedClassIndicator.functor()->stringForm());
-					if(definedClass->isSubClassOf(rdfClass)) {
+					if(kb_->vocabulary()->defineClass(definedClassIndicator.functor()->stringForm())) {
+						auto definedClass = kb_->vocabulary()->defineClass(definedClassIndicator.functor()->stringForm());
 						reasoners.push_back({x.second, definedClass->iriAtom()});
 						break;
 					}
@@ -71,8 +71,8 @@ std::vector<DefiningReasoner> ReasonerManager::findDefiningReasoner(const Predic
 		if (rdfProperty) {
 			for (auto &x: goalDriven_) {
 				for (auto &definedPropertyIndicator : x.second->definedRelations()) {
-					auto definedProperty = kb_->vocabulary()->defineProperty(definedPropertyIndicator.functor()->stringForm());
-					if(definedProperty->isSubPropertyOf(rdfProperty)) {
+                    if ( kb_->vocabulary()->isDefinedProperty(definedPropertyIndicator.functor()->stringForm())) { 
+                    	auto definedProperty = kb_->vocabulary()->defineProperty(definedPropertyIndicator.functor()->stringForm());
 						reasoners.push_back({x.second, definedProperty->iriAtom()});
 						break;
 					}


### PR DESCRIPTION
This fixes warnings of this form:

[11:52:35.409] [warning] Resource created with guessed literal type: action_cancelled. Treating as IRI.
[11:52:35.410] [warning] Resource created with guessed literal type: action_active. Treating as IRI.
[11:53:03.783] [warning] Resource created with guessed literal type: Reified_object_f. Treating as IRI.
[11:53:03.784] [warning] Resource created with guessed literal type: Reified_has_sube. Treating as IRI.
[11:53:03.784] [warning] Resource created with guessed literal type: Reified_has_disp. Treating as IRI.
[11:53:03.784] [warning] Resource created with guessed literal type: Reified_is_situa. Treating as IRI.
[11:53:03.784] [warning] Resource created with guessed literal type: Reified_is_patie. Treating as IRI.
[11:53:03.785] [warning] Resource created with guessed literal type: Reified_is_locat. Treating as IRI.
[11:53:03.785] [warning] Resource created with guessed literal type: Reified_is_bindi. Treating as IRI.
[11:53:03.785] [warning] Resource created with guessed literal type: Reified_has_task. Treating as IRI.
[11:53:03.785] [warning] Resource created with guessed literal type: Reified_has_part. Treating as IRI.
[11:53:03.785] [warning] Resource created with guessed literal type: Reified_is_event_type. Treating as IRI.
[11:53:03.786] [warning] Resource created with guessed literal type: Reified_is_conce. Treating as IRI.