### PR TITLE
Avoid program abortion when Python forces shutdown of library

### DIFF
--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -204,6 +204,10 @@ void ThreadPool::Runner::runInternal() {
 			KB_WARN("Worker error: {}.", e.what());
 		}
 	}
+	catch (abi::__forced_unwind const&) {
+		// this is a forced unwind, rethrow
+		throw;
+    }
 	catch (...) {
 		KB_WARN("Unknown worker error.");
 	}

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -205,7 +205,8 @@ void ThreadPool::Runner::runInternal() {
 		}
 	}
 	catch (abi::__forced_unwind const&) {
-		// this is a forced unwind, rethrow
+		// this is a forced unwind, rethrow. this happens when the thread is cancelled.
+		KB_WARN("Worker forced unwind.");
 		throw;
     }
 	catch (...) {

--- a/src/knowrob.cpp
+++ b/src/knowrob.cpp
@@ -9,7 +9,6 @@
 #include <knowrob/ThreadPool.h>
 #include <filesystem>
 #include <iostream>
-#include <locale>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include "knowrob/integration/python/PythonError.h"
@@ -61,7 +60,7 @@ namespace knowrob {
 		setenv("PYTHONPATH", pythonPathStr.c_str(), 1);
 	}
 
-	void InitKnowRob(int argc, char **argv, bool initPython) {
+	void InitKnowRob(char **argv, bool initPython) {
 		// remember the program name.
 		// it is assumed here that argv stays valid during program execution.
 		knowrob::NAME_OF_EXECUTABLE = argv[0];
@@ -90,14 +89,17 @@ namespace knowrob {
 		initialized = true;
 	}
 
+	void InitKnowRob(int /*argc*/, char **argv, bool initPython) {
+		InitKnowRob(argv, initPython);
+	}
+
 	static void InitKnowRobFromPython(boost::python::list py_argv) {
 		if (initialized) return;
 
-		static auto argc = boost::python::len(py_argv);
 		static std::vector<std::string> arg_strings;
 		static std::vector<char *> argv;
 
-		for (int i = 0; i < argc; ++i) {
+		for (auto i = 0; i < boost::python::len(py_argv); ++i) {
 			std::string arg = boost::python::extract<std::string>(py_argv[i]);
 			arg_strings.push_back(arg);
 		}
@@ -107,7 +109,7 @@ namespace knowrob {
 		}
 
 		// Call the actual InitKnowRob function with the converted arguments
-		knowrob::InitKnowRob(argc, argv.data(), false);
+		knowrob::InitKnowRob(argv.data(), false);
 	}
 
 	void InitKnowRobFromPythonSysArgv() {
@@ -145,5 +147,6 @@ namespace knowrob::py {
 		// mappings for static functions
 		def("InitKnowRobWithArgs", &InitKnowRobFromPython, "Initialize the Knowledge Base with arguments.");
 		def("InitKnowRob", &InitKnowRobFromPythonSysArgv, "Initialize the Knowledge Base using sys.argv.");
+		def("ShutdownKnowRob", &ShutdownKnowRob);
 	}
 }

--- a/tests/KnowledgeBaseTest.cpp
+++ b/tests/KnowledgeBaseTest.cpp
@@ -374,7 +374,7 @@ TEST_F(KnowledgeBaseTest, mongolog_lpn_json) {
 	kb_ = KnowledgeBase::create("tests/settings/mongolog-lpn.json");
 	EXPECT_ONLY_SOLUTION(
 			"lpn:jealous(lpn:vincent, X)",
-			Bindings({{varX_, iri("lpn","marsellus")}}))
+			Bindings({{varX_, iri("lpn", "marsellus")}}))
 	kb_ = nullptr;
 }
 

--- a/tests/py/lpn_reasoner.py
+++ b/tests/py/lpn_reasoner.py
@@ -1,9 +1,9 @@
 from knowrob import *
 
 
-class DummyReasoner(RDFGoalReasoner):
+class LPNReasoner(RDFGoalReasoner):
 	def __init__(self):
-		super(DummyReasoner, self).__init__()
+		super(LPNReasoner, self).__init__()
 		self.loves = IRIAtom("http://knowrob.org/kb/lpn#loves")
 		# The reasoner defines a new predicate lpn:jealous that can be evaluated by the reasoner
 		self.defineRelation(IRIAtom("http://knowrob.org/kb/lpn#jealous"))

--- a/tests/settings/python-lpn.json
+++ b/tests/settings/python-lpn.json
@@ -26,9 +26,9 @@
   ],
   "reasoner": [
     {
-      "type": "DummyReasoner",
-      "name": "DummyReasoner",
-      "module": "tests/py/dummy_reasoner.py",
+      "type": "LPNReasoner",
+      "name": "lpn",
+      "module": "tests/py/lpn_reasoner.py",
       "data-backend": "mongodb"
     }
   ]


### PR DESCRIPTION
Python seems to force exit threads in some cases which appears to need some special handling.
Rethrowing of a special exception is needed to avoid abortion.
Best to call `ShutdownKnowRob` to avoid unclean shutdown