### PR TITLE
Prolog assert retract

### DIFF
--- a/src/reasoner/prolog/semweb.cpp
+++ b/src/reasoner/prolog/semweb.cpp
@@ -167,6 +167,70 @@ foreign_t sw_load_rdf_xml4(term_t t_manager, term_t t_reasoner, term_t t_url, te
 	return false;
 }
 
+foreign_t sw_assert6(term_t t_manager, term_t t_reasoner, term_t t_subject, term_t t_predicate, term_t t_object, term_t t_graph) {
+	auto kb = getKnowledgeBase(t_manager, t_reasoner);
+	if (!kb) return false;
+	auto s = PrologTerm::toKnowRobTerm(t_subject);
+	auto p = PrologTerm::toKnowRobTerm(t_predicate);
+	auto o = PrologTerm::toKnowRobTerm(t_object);
+	if (!s || !p || !o) return false;
+	TripleView tripleData;
+	tripleData.setSubject(((Atomic *) s.get())->stringForm());
+	tripleData.setPredicate(((Atomic *) p.get())->stringForm());
+	if(o->termType() == TermType::ATOMIC) {
+		auto atomic = std::static_pointer_cast<Atomic>(o);
+		if (atomic->isNumeric()) {
+			tripleData.setXSDValue(atomic->stringForm(),
+				std::static_pointer_cast<Numeric>(atomic)->xsdType());
+		} else if (atomic->isIRI()) {
+			tripleData.setObjectIRI(atomic->stringForm());
+		} else if (atomic->isBlank()) {
+			tripleData.setObjectBlank(atomic->stringForm());
+		} else {
+			tripleData.setStringValue(atomic->stringForm());
+		}
+	} else {
+		return false;
+	}
+	auto g = PrologTerm::toKnowRobTerm(t_graph);
+	if (g && g->termType() == TermType::ATOMIC) {
+		tripleData.setGraph(((Atomic *) g.get())->stringForm());
+	}
+	return kb->insertOne(tripleData);
+}
+
+foreign_t sw_retract6(term_t t_manager, term_t t_reasoner, term_t t_subject, term_t t_predicate, term_t t_object, term_t t_graph) {
+	auto kb = getKnowledgeBase(t_manager, t_reasoner);
+	if (!kb) return false;
+	auto s = PrologTerm::toKnowRobTerm(t_subject);
+	auto p = PrologTerm::toKnowRobTerm(t_predicate);
+	auto o = PrologTerm::toKnowRobTerm(t_object);
+	if (!s || !p || !o) return false;
+	TripleView tripleData;
+	tripleData.setSubject(((Atomic *) s.get())->stringForm());
+	tripleData.setPredicate(((Atomic *) p.get())->stringForm());
+	if(o->termType() == TermType::ATOMIC) {
+		auto atomic = std::static_pointer_cast<Atomic>(o);
+		if (atomic->isNumeric()) {
+			tripleData.setXSDValue(atomic->stringForm(),
+				std::static_pointer_cast<Numeric>(atomic)->xsdType());
+		} else if (atomic->isIRI()) {
+			tripleData.setObjectIRI(atomic->stringForm());
+		} else if (atomic->isBlank()) {
+			tripleData.setObjectBlank(atomic->stringForm());
+		} else {
+			tripleData.setStringValue(atomic->stringForm());
+		}
+	} else {
+		return false;
+	}
+	auto g = PrologTerm::toKnowRobTerm(t_graph);
+	if (g && g->termType() == TermType::ATOMIC) {
+		tripleData.setGraph(((Atomic *) g.get())->stringForm());
+	}
+	return kb->removeOne(tripleData);
+}
+
 namespace knowrob::prolog {
 	PL_extension PL_extension_semweb[] = {
 			{"sw_url_graph",                   2, (pl_function_t) sw_url_graph2,                0},
@@ -185,6 +249,8 @@ namespace knowrob::prolog {
 			{"sw_set_current_graph_cpp",       3, (pl_function_t) sw_set_current_graph3,       0},
 			{"sw_unset_current_graph_cpp",     3, (pl_function_t) sw_unset_current_graph3,     0},
 			{"sw_load_rdf_xml_cpp",            4, (pl_function_t) sw_load_rdf_xml4,            0},
+			{"sw_assert_cpp",                  6, (pl_function_t) sw_assert6,				    0},
+			{"sw_retract_cpp",                 6, (pl_function_t) sw_retract6,                 0},
 			{nullptr,                          0, nullptr,                                     0}
 	};
 }

--- a/src/reasoner/prolog/semweb.pl
+++ b/src/reasoner/prolog/semweb.pl
@@ -46,6 +46,8 @@
       sw_register_computable(r),   % +RDF_predicate
       sw_register_computable(r,+), % +RDF_predicate
 
+      sw_assert/4,               % +Subject, +Predicate, +Object, +Graph
+      sw_retract/4,              % +Subject, +Predicate, +Object, +Graph
       load_rdf_xml/2               % +URL, +ParentGraph
     ]).
 /** <module> Extensions around the semweb modules of Prolog.
@@ -789,6 +791,30 @@ sw_set_default_graph(Graph) :-
     current_reasoner_manager(ReasonerManager),
     current_reasoner_module(Reasoner),
 	sw_set_default_graph_cpp(ReasonerManager, Reasoner, Graph).
+
+     /*******************************
+      *    ASSERT / RETRACT    *
+      *******************************/
+
+%% sw_assert(+Subject, +Predicate, +Object, +Graph) is det.
+%
+% Assert a new triple into the database.
+%
+sw_assert(Subject, Predicate, Object, Graph) :-
+    atom(Subject), atom(Predicate), ground(Object),!,
+    current_reasoner_manager(ReasonerManager),
+    current_reasoner_module(Reasoner),
+    sw_assert_cpp(ReasonerManager, Reasoner, Subject, Predicate, Object, Graph).
+
+%% sw_retract(+Subject, +Predicate, +Object, +Graph) is det.
+%
+% Retract a triple from the database.
+%
+sw_retract(Subject, Predicate, Object, Graph) :-
+    atom(Subject), atom(Predicate), ground(Object),!,
+    current_reasoner_manager(ReasonerManager),
+    current_reasoner_module(Reasoner),
+    sw_retract_cpp(ReasonerManager, Reasoner, Subject, Predicate, Object, Graph).
 
      /*******************************
       *    LOADING RDF/XML DATA     *


### PR DESCRIPTION
Added utility predicates sw_assert/4 and sw_retract/4 to Prolog that allow to assert/retract a single triple from knowrob storage backends.