### PR TITLE
Modify boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,11 +324,17 @@ set(KNOWROB_LIBRARIES
         ${GTEST_LIBRARIES})
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
-install(TARGETS knowrob
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
-install(FILES $<TARGET_FILE:knowrob>
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-        RENAME libknowrob${PYTHON3_SUFFIX})
+
+option(KNOWROB_USE_SUFFIX "Append fixed suffix to KnowRob module name" OFF)
+if(KNOWROB_USE_SUFFIX)
+	install(FILES $<TARGET_FILE:knowrob>
+			DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+			RENAME libknowrob${PYTHON3_SUFFIX})
+else()
+	install(TARGETS knowrob
+			PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
+endif()
+
 install(DIRECTORY include/knowrob
         DESTINATION include)
 # Install Python and Prolog files into the share directory such that they can be loaded at runtime.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,8 @@ target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 
 if(KNOWROB_USE_SUFFIX)
 	message(STATUS "Installing knowrob with suffix ${PYTHON3_SUFFIX}")
-	set_target_properties(knowrob PROPERTIES OUTPUT_NAME "knowrob${PYTHON3_SUFFIX}")
+	string(REPLACE ".so" "" PYTHON3_SUFFIX_BASE "${PYTHON3_SUFFIX}")
+	set_target_properties(knowrob PROPERTIES OUTPUT_NAME "knowrob${PYTHON3_SUFFIX_BASE}")
 endif()
 install(TARGETS knowrob
 		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,20 +46,31 @@ find_package(spdlog REQUIRED)
 set(Python3_EXECUTABLE "/usr/bin/python" CACHE FILEPATH "Path to specific Python3 executable")
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 execute_process(
-    COMMAND python3-config --extension-suffix
+    COMMAND python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}-config --extension-suffix
     OUTPUT_VARIABLE PYTHON3_SUFFIX
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 # Construct Boost Python component name based on Python version
-set(Boost_Python_VERSION "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" CACHE FILEPATH "Boost Python version")
+set(Boost_Python_VERSION "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
 set(Boost_Python_COMPONENT "Boost::${Boost_Python_VERSION}")
 message(STATUS "Using Boost Python component: ${Boost_Python_COMPONENT}")
 
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.50 REQUIRED COMPONENTS program_options serialization ${Boost_Python_VERSION})
+
+if(DEFINED Boost_ROOT AND Boost_ROOT)
+	# Enable Boost_ROOT usage properly
+	if(POLICY CMP0074)
+		cmake_policy(SET CMP0074 NEW)
+	endif()
+	# Set CMake's internal Boost root hint
+	message(STATUS "Using user-defined Boost_ROOT: ${Boost_ROOT}")
+	find_package(Boost REQUIRED COMPONENTS program_options serialization ${Boost_Python_VERSION})
+else()
+  	find_package(Boost 1.50 REQUIRED COMPONENTS program_options serialization ${Boost_Python_VERSION})
+endif()
 
 enable_testing()
 find_package(GTest REQUIRED)
@@ -311,15 +322,11 @@ set(KNOWROB_LIBRARIES
         ${GTEST_LIBRARIES})
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
+install(TARGETS knowrob
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
 install(FILES $<TARGET_FILE:knowrob>
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
         RENAME libknowrob${PYTHON3_SUFFIX})
-        install(CODE "
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-            libknowrob${PYTHON3_SUFFIX}
-            \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/libknowrob.so
-        )
-        message(STATUS \"Created symlink libknowrob.so → libknowrob${PYTHON3_SUFFIX}\")")
 install(DIRECTORY include/knowrob
         DESTINATION include)
 # Install Python and Prolog files into the share directory such that they can be loaded at runtime.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(knowrob_INCLUDE_DIRS
         ${REDLAND_INCLUDE_DIRS})
 include_directories(${knowrob_INCLUDE_DIRS})
 
+option(KNOWROB_USE_SUFFIX "Append fixed suffix to KnowRob module name" OFF)
 add_library(knowrob SHARED
         src/knowrob.cpp
         src/ThreadPool.cpp
@@ -325,15 +326,12 @@ set(KNOWROB_LIBRARIES
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
 
-option(KNOWROB_USE_SUFFIX "Append fixed suffix to KnowRob module name" OFF)
 if(KNOWROB_USE_SUFFIX)
-	install(FILES $<TARGET_FILE:knowrob>
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-			RENAME libknowrob${PYTHON3_SUFFIX})
-else()
-	install(TARGETS knowrob
-			PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
+	message(STATUS "Installing knowrob with suffix ${PYTHON3_SUFFIX}")
+	set_target_properties(knowrob PROPERTIES OUTPUT_NAME "knowrob${PYTHON3_SUFFIX}")
 endif()
+install(TARGETS knowrob
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
 
 install(DIRECTORY include/knowrob
         DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ find_package(PkgConfig REQUIRED)
 find_package(spdlog REQUIRED)
 set(Python3_EXECUTABLE "/usr/bin/python" CACHE FILEPATH "Path to specific Python3 executable")
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+message(STATUS "Found Python3 include: ${Python3_INCLUDE_DIRS}")
+message(STATUS "Found Python3 libraries: ${Python3_LIBRARIES}")
 execute_process(
     COMMAND python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}-config --extension-suffix
     OUTPUT_VARIABLE PYTHON3_SUFFIX
@@ -132,7 +134,7 @@ if (CATKIN)
         catkin_package(
                 INCLUDE_DIRS include
                 LIBRARIES knowrob
-                DEPENDS Boost -lswipl MONGOC RAPTOR REDLAND spdlog Python GTest EIGEN3
+                DEPENDS Boost -lswipl MONGOC RAPTOR REDLAND spdlog Python3 GTest EIGEN3
         )
     else ()
         message(STATUS "No catkin workspace found.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,16 @@ include("cmake/ontologies.cmake")
 find_package(Eigen3 REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(spdlog REQUIRED)
-find_package(Python COMPONENTS Interpreter Development)
+set(Python3_EXECUTABLE "/usr/bin/python" CACHE FILEPATH "Path to specific Python3 executable")
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+execute_process(
+    COMMAND python3-config --extension-suffix
+    OUTPUT_VARIABLE PYTHON3_SUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 # Construct Boost Python component name based on Python version
-set(Boost_Python_VERSION "python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}")
+set(Boost_Python_VERSION "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" CACHE FILEPATH "Boost Python version")
 set(Boost_Python_COMPONENT "Boost::${Boost_Python_VERSION}")
 message(STATUS "Using Boost Python component: ${Boost_Python_COMPONENT}")
 
@@ -131,7 +137,7 @@ set(knowrob_INCLUDE_DIRS
         ${SWIPL_INCLUDE_DIRS}
         ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
-        ${Python_INCLUDE_DIRS}
+        ${Python3_INCLUDE_DIRS}
         ${MONGOC_INCLUDE_DIRS}
         ${RAPTOR_INCLUDE_DIRS}
         ${REDLAND_INCLUDE_DIRS})
@@ -300,13 +306,20 @@ set(KNOWROB_LIBRARIES
         ${MONGOC_LIBRARIES}
         ${RAPTOR_LIBRARIES}
         ${REDLAND_LIBRARIES}
-        ${Python_LIBRARIES}
+        ${Python3_LIBRARIES}
         spdlog::spdlog
         ${GTEST_LIBRARIES})
 target_link_libraries(knowrob ${KNOWROB_LIBRARIES})
 # install shared library and headers
-install(TARGETS knowrob
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/knowrob)
+install(FILES $<TARGET_FILE:knowrob>
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        RENAME libknowrob${PYTHON3_SUFFIX})
+        install(CODE "
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+            libknowrob${PYTHON3_SUFFIX}
+            \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/libknowrob.so
+        )
+        message(STATUS \"Created symlink libknowrob.so → libknowrob${PYTHON3_SUFFIX}\")")
 install(DIRECTORY include/knowrob
         DESTINATION include)
 # Install Python and Prolog files into the share directory such that they can be loaded at runtime.
@@ -350,7 +363,7 @@ target_include_directories(knowrob_py PRIVATE
         ${SWIPL_INCLUDE_DIRS}
         ${EIGEN3_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
-        ${PYTHON_INCLUDE_DIRS})
+        ${PYTHON3_INCLUDE_DIRS})
 target_link_libraries(knowrob_py PRIVATE
         ${KNOWROB_LIBRARIES}
         Boost::program_options
@@ -382,7 +395,8 @@ else ()
 endif()
 # install the Python module into the site-packages directory
 install(FILES ${CMAKE_BINARY_DIR}/knowrob.so
-        DESTINATION lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/${PYTHON_MODULE_LIBDIR})
+        DESTINATION lib/python/${PYTHON_MODULE_LIBDIR}
+        RENAME knowrob${PYTHON3_SUFFIX})
 
 ##############
 ########## Doxygen


### PR DESCRIPTION
### ❗ Problem

Ubuntu 20.04 only provides `libboost-python38` out of the box:

```bash
$ ldconfig -p | grep libboost_python
        libboost_python38.so.1.71.0 (libc6,x86-64) => /lib/x86_64-linux-gnu/libboost_python38.so.1.71.0
        libboost_python38.so           (libc6,x86-64) => /lib/x86_64-linux-gnu/libboost_python38.so
```

This means it's **not possible to build `knowrob.so` with Python bindings for versions other than Python 3.8** (e.g. Python 3.10 or 3.12), because matching `libboost_python` libraries for those versions aren't available.

---

### ✅ Solution

Manually **build Boost from [source (Boost 1.88.0)](https://github.com/boostorg/boost/releases/tag/boost-1.88.0)** and configure the KnowRob build system to use your custom Boost installation.

This fix involves updating the KnowRob `CMakeLists.txt` to accept a user-defined Boost path (via `Boost_ROOT`), instead of relying on the default system Boost. Additionally, it introduces an option to append a fixed suffix to `libknowrob.so` (e.g., resulting in `libknowrob.cpython-310-x86_64-linux-gnu.so`).

---

### 🛠️ Verification

After applying the fix, KnowRob can be built for multiple Python versions like so:

```bash
cd knowrob
mkdir build install
cd build

# Build with Python 3.8
cmake -DCATKIN=OFF \
      -DPYTHON_MODULE_LIBDIR="dist-packages" \
      -DCMAKE_INSTALL_PREFIX=$PWD/../install \
      -DPython3_EXECUTABLE=/usr/bin/python3.8 \
      -DKNOWROB_USE_SUFFIX=ON \
      -DBoost_ROOT=</path/to>/boost-1.88.0/install ..
make install
rm -rf *

# Build with Python 3.10
cmake -DCATKIN=OFF \
      -DPYTHON_MODULE_LIBDIR="dist-packages" \
      -DCMAKE_INSTALL_PREFIX=$PWD/../install \
      -DPython3_EXECUTABLE=/usr/bin/python3.10 \
      -DKNOWROB_USE_SUFFIX=ON \
      -DBoost_ROOT=</path/to>/boost-1.88.0/install ..
make install
rm -rf *

# Build with Python 3.12
cmake -DCATKIN=OFF \
      -DPYTHON_MODULE_LIBDIR="dist-packages" \
      -DCMAKE_INSTALL_PREFIX=$PWD/../install \
      -DPython3_EXECUTABLE=/usr/bin/python3.12 \
      -DKNOWROB_USE_SUFFIX=ON \
      -DBoost_ROOT=</path/to>/boost-1.88.0/install ..
make install
```

---

After running these builds, KnowRob will be installed under `knowrob/install`, with support for **Python 3.8, 3.10, and 3.12**, each compiled against its corresponding `libboost_python`.

Here is the result:

![image](https://github.com/user-attachments/assets/f3f8a73c-accf-4026-82f9-a7b848b6af62)

Compiled libraries:
[boost.zip](https://github.com/user-attachments/files/19968445/boost.zip)
[knowrob.zip](https://github.com/user-attachments/files/19968447/knowrob.zip)
