### PR TITLE
Exporting triples to file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(knowrob SHARED
         src/integration/python/utils.cpp
         src/semweb/Triple.cpp
         src/semweb/TripleFormat.cpp
+        src/semweb/TripleFormatter.cpp
         src/semweb/OntologyLanguage.cpp
         src/reasoner/prolog/semweb.cpp
         src/integration/prolog/PrologBackend.cpp

--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -175,6 +175,14 @@ namespace knowrob {
 		bool removeAllWithOrigin(std::string_view origin);
 
 		/**
+		 * Export all triples in the model to a file.
+		 * @param filename the name of the file to export to.
+		 * @param format the format of the output file.
+		 */
+		bool exportTo(const std::string &filename,
+					  semweb::TripleFormat format=semweb::RDF_XML) const;
+
+		/**
 		 * Set the default graph for queries.
 		 * @param origin the origin of the default graph
 		 */

--- a/include/knowrob/KnowledgeBase.h
+++ b/include/knowrob/KnowledgeBase.h
@@ -178,6 +178,7 @@ namespace knowrob {
 		 * Export all triples in the model to a file.
 		 * @param filename the name of the file to export to.
 		 * @param format the format of the output file.
+		 * @return true if the export was successful
 		 */
 		bool exportTo(const std::string &filename,
 					  semweb::TripleFormat format=semweb::RDF_XML) const;

--- a/include/knowrob/semweb/TripleFormatter.h
+++ b/include/knowrob/semweb/TripleFormatter.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#ifndef KNOWROB_TRIPLE_FORMATTER_H
+#define KNOWROB_TRIPLE_FORMATTER_H
+
+#include "string_view"
+#include "map"
+#include "knowrob/semweb/TripleFormat.h"
+#include "knowrob/semweb/Triple.h"
+
+namespace knowrob::semweb {
+	/**
+	 * A class that is responsible for exporting triples to different formats.
+	 */
+	class TripleFormatter {
+	public:
+		/**
+		 * @param triples a map of triples
+		 * @param filename the name of the file to export to
+		 * @param format the format of the output file
+		 * @return true if the export was successful
+		 */
+		static bool exportTo(
+              const std::map<std::string_view, TriplePtr> &triples,
+              const std::string &filename,
+              TripleFormat format = TripleFormat::RDF_XML);
+
+		/**
+		 * @param triples a map of triples
+		 * @param filename the name of the file to export to
+		 * @return true if the export was successful
+		 */
+		static bool exportRDF_XML(
+              const std::map<std::string_view, TriplePtr> &triples,
+			  const std::string &filename);
+	};
+}
+
+#endif //KNOWROB_TRIPLE_FORMATTER_H

--- a/include/knowrob/semweb/TripleFormatter.h
+++ b/include/knowrob/semweb/TripleFormatter.h
@@ -12,31 +12,31 @@
 #include "knowrob/semweb/Triple.h"
 
 namespace knowrob::semweb {
-	/**
-	 * A class that is responsible for exporting triples to different formats.
-	 */
-	class TripleFormatter {
-	public:
-		/**
-		 * @param triples a map of triples
-		 * @param filename the name of the file to export to
-		 * @param format the format of the output file
-		 * @return true if the export was successful
-		 */
-		static bool exportTo(
-              const std::map<std::string_view, TriplePtr> &triples,
-              const std::string &filename,
-              TripleFormat format = TripleFormat::RDF_XML);
+    /**
+     * A class that is responsible for exporting triples to different formats.
+     */
+    class TripleFormatter {
+    public:
+        /**
+         * @param triples a map of triples
+         * @param filename the name of the file to export to
+         * @param format the format of the output file
+         * @return true if the export was successful
+         */
+        static bool exportTo(
+            const std::map<std::string_view, TriplePtr> &triples,
+            const std::string &filename,
+            TripleFormat format = TripleFormat::RDF_XML);
 
-		/**
-		 * @param triples a map of triples
-		 * @param filename the name of the file to export to
-		 * @return true if the export was successful
-		 */
-		static bool exportRDF_XML(
-              const std::map<std::string_view, TriplePtr> &triples,
-			  const std::string &filename);
-	};
+        /**
+         * @param triples a map of triples
+         * @param filename the name of the file to export to
+         * @return true if the export was successful
+         */
+        static bool exportRDF_XML(
+            const std::map<std::string_view, TriplePtr> &triples,
+            const std::string &filename);
+    };
 }
 
 #endif //KNOWROB_TRIPLE_FORMATTER_H

--- a/include/knowrob/semweb/TripleFormatter.h
+++ b/include/knowrob/semweb/TripleFormatter.h
@@ -36,6 +36,15 @@ namespace knowrob::semweb {
         static bool exportRDF_XML(
             const std::map<std::string_view, TriplePtr> &triples,
             const std::string &filename);
+
+        /**
+         * @param triples a map of triples
+         * @param filename the name of the file to export to
+         * @return true if the export was successful
+         */
+        static bool exportTurtle(
+            const std::map<std::string_view, TriplePtr> &triples,
+            const std::string &filename);
     };
 }
 

--- a/include/knowrob/storage/QueryableStorage.h
+++ b/include/knowrob/storage/QueryableStorage.h
@@ -87,6 +87,7 @@ namespace knowrob {
 		 * Export all triples in the model to a file.
 		 * @param filename the name of the file to export to.
 		 * @param format the format of the output file.
+		 * @return true if the export was successful
 		 */
 		bool exportTo(const std::string &filename,
 		              semweb::TripleFormat format=semweb::RDF_XML) const;

--- a/include/knowrob/storage/QueryableStorage.h
+++ b/include/knowrob/storage/QueryableStorage.h
@@ -6,6 +6,8 @@
 #ifndef KNOWROB_QUERYABLE_STORAGE_H
 #define KNOWROB_QUERYABLE_STORAGE_H
 
+#include <knowrob/semweb/TripleFormat.h>
+
 #include "knowrob/queries/TokenBuffer.h"
 #include "Storage.h"
 #include "knowrob/queries/Answer.h"
@@ -80,6 +82,14 @@ namespace knowrob {
 		 * @param callback a function that is called for each resource and its count.
 		 */
 		virtual void count(const ResourceCounter &callback) const = 0;
+
+		/**
+		 * Export all triples in the model to a file.
+		 * @param filename the name of the file to export to.
+		 * @param format the format of the output file.
+		 */
+		bool exportTo(const std::string &filename,
+		              semweb::TripleFormat format=semweb::RDF_XML) const;
 
 		/**
 		 * @return a list of all origins that have been asserted.

--- a/src/KnowledgeBase.cpp
+++ b/src/KnowledgeBase.cpp
@@ -740,6 +740,7 @@ namespace knowrob::py {
 						fn(bindings);
 					});
 				})
+				.def("exportTo", with<no_gil>(&KnowledgeBase::exportTo))
 				.def("insertOne", with<no_gil>(&KnowledgeBase::insertOne))
 				.def("insertAll", with<no_gil>(static_cast<ContainerAction>(&KnowledgeBase::insertAll)))
 				.def("insertAll", with<no_gil>(static_cast<ListAction>(&KnowledgeBase::insertAll)))

--- a/src/KnowledgeBase.cpp
+++ b/src/KnowledgeBase.cpp
@@ -677,6 +677,15 @@ bool KnowledgeBase::loadNonOntologySource(const DataSourcePtr &source) const {
 	return hasHandler && allSucceeded;
 }
 
+bool KnowledgeBase::exportTo(const std::string &filename, semweb::TripleFormat format) const {
+	auto backend = getBackendForQuery();
+	if (!backend) {
+		KB_ERROR("No backend available for exporting.");
+		return false;
+	}
+	return backend->exportTo(filename, format);
+}
+
 void KnowledgeBase::setDefaultGraph(std::string_view origin) {
 	vocabulary_->importHierarchy()->setDefaultGraph(origin);
 }

--- a/src/semweb/TripleFormatter.cpp
+++ b/src/semweb/TripleFormatter.cpp
@@ -16,6 +16,8 @@ bool knowrob::semweb::TripleFormatter::exportTo(
     switch (format) {
         case TripleFormat::RDF_XML:
             return exportRDF_XML(triples, filename);
+        case TripleFormat::TURTLE:
+            return exportTurtle(triples, filename);
         default:
             // Unsupported format
             KB_WARN("Unsupported format: {}", tripleFormatToString(format));
@@ -23,14 +25,17 @@ bool knowrob::semweb::TripleFormatter::exportTo(
     }
 }
 
-bool knowrob::semweb::TripleFormatter::exportRDF_XML(
-    const std::map<std::string_view, TriplePtr> &triples,
-    const std::string &filename) {
-    // make sure the directory exists
+static void ensureDirectoryExists(const std::string &filename) {
     std::filesystem::path path(filename);
     if (path.has_parent_path()) {
         std::filesystem::create_directories(path.parent_path());
     }
+}
+
+bool knowrob::semweb::TripleFormatter::exportRDF_XML(
+    const std::map<std::string_view, TriplePtr> &triples,
+    const std::string &filename) {
+    ensureDirectoryExists(filename);
     // open file for writing, overwrite if it exists
     std::ofstream file(filename);
     if (!file.is_open()) {
@@ -69,6 +74,47 @@ bool knowrob::semweb::TripleFormatter::exportRDF_XML(
     }
     // write RDF/XML footer
     file << "</rdf:RDF>\n";
+    file.close();
+    return true;
+}
+
+bool knowrob::semweb::TripleFormatter::exportTurtle(
+    const std::map<std::string_view, TriplePtr> &triples,
+    const std::string &filename) {
+    ensureDirectoryExists(filename);
+    // open file for writing, overwrite if it exists
+    std::ofstream file(filename);
+    if (!file.is_open()) {
+        KB_WARN("Could not open file {} for writing.", filename);
+        return false;
+    }
+    // write Turtle header
+    file << "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n";
+    file << "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n";
+    file << "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n";
+    // iterate over known namespaces
+    for (const auto &[uri, prefix]: PrefixRegistry::get()) {
+        file << "@prefix " << prefix << ": <" << uri << "> .\n";
+    }
+    // write triples
+    for (const auto &[subject, triple]: triples) {
+        file << subject << " ";
+        auto property = triple->predicate();
+        auto valueString = triple->createStringValue();
+        auto valueType = triple->xsdType();
+        if (triple->isXSDLiteral()) {
+            // XSD property assertion
+            file << property << " \"" << valueString << "\"^^<" << xsdTypeToIRI(valueType.value()) << "> .\n";
+        } else if (triple->isObjectIRI()) {
+            // object property assertion
+            file << property << " <" << valueString << "> .\n";
+        } else {
+            // untyped literal
+            file << property << " \"" << valueString << "\" .\n";
+        }
+    }
+    // write Turtle footer
+    file << "\n";
     file.close();
     return true;
 }

--- a/src/semweb/TripleFormatter.cpp
+++ b/src/semweb/TripleFormatter.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <filesystem>
+#include <fstream>
 #include "knowrob/semweb/TripleFormatter.h"
 #include "knowrob/semweb/PrefixRegistry.h"
 #include "knowrob/Logger.h"

--- a/src/semweb/TripleFormatter.cpp
+++ b/src/semweb/TripleFormatter.cpp
@@ -1,0 +1,73 @@
+/*
+ * This file is part of KnowRob, please consult
+ * https://github.com/knowrob/knowrob for license details.
+ */
+
+#include <filesystem>
+#include "knowrob/semweb/TripleFormatter.h"
+#include "knowrob/semweb/PrefixRegistry.h"
+#include "knowrob/Logger.h"
+
+bool knowrob::semweb::TripleFormatter::exportTo(
+        const std::map<std::string_view, TriplePtr> &triples,
+        const std::string &filename,
+        TripleFormat format) {
+    switch (format) {
+        case TripleFormat::RDF_XML:
+            return exportRDF_XML(triples, filename);
+        default:
+            // Unsupported format
+            KB_WARN("Unsupported format: {}", tripleFormatToString(format));
+            return false;
+    }
+}
+
+bool knowrob::semweb::TripleFormatter::exportRDF_XML(
+        const std::map<std::string_view, TriplePtr> &triples,
+        const std::string &filename) {
+    // make sure the directory exists
+    std::filesystem::path path(filename);
+    if (path.has_parent_path()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    // open file for writing, overwrite if it exists
+    std::ofstream file(filename);
+    if (!file.is_open()) {
+        KB_WARN("Could not open file {} for writing.", filename);
+        return false;
+    }
+    // write RDF/XML header
+    file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    file << "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n";
+    file << "         xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\"\n";
+    file << "         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\n";
+    // iterate over known namespaces
+    for (const auto &[uri, prefix] : PrefixRegistry::get()) {
+        file << "         xmlns:" << prefix << "=\"" << uri << "\"\n";
+    }
+    file << ">\n";
+
+    // write triples
+    for (const auto &[subject,triple] : triples) {
+        file << "  <rdf:Description rdf:about=\"" << subject << "\">\n";
+        auto property = triple->predicate();
+        auto valueString = triple->createStringValue();
+        auto valueType = triple->xsdType();
+        if (triple->isXSDLiteral()) {
+            // XSD property assertion
+            file << "    <" << property << " rdf:datatype=\"" << xsdTypeToIRI(valueType.value()) << "\">";
+            file << valueString << "</" << property << ">\n";
+        } else if (triple->isObjectIRI()) {
+            // object property assertion
+            file << "    <" << property << " rdf:resource=\"" << valueString << "\"/>\n";
+        } else {
+            // untyped literal
+            file << "    <" << property << ">" << valueString << "</" << property << ">\n";
+        }
+        file << "  </rdf:Description>\n";
+    }
+    // write RDF/XML footer
+    file << "</rdf:RDF>\n";
+    file.close();
+    return true;
+}

--- a/src/semweb/TripleFormatter.cpp
+++ b/src/semweb/TripleFormatter.cpp
@@ -9,9 +9,9 @@
 #include "knowrob/Logger.h"
 
 bool knowrob::semweb::TripleFormatter::exportTo(
-        const std::map<std::string_view, TriplePtr> &triples,
-        const std::string &filename,
-        TripleFormat format) {
+    const std::map<std::string_view, TriplePtr> &triples,
+    const std::string &filename,
+    TripleFormat format) {
     switch (format) {
         case TripleFormat::RDF_XML:
             return exportRDF_XML(triples, filename);
@@ -23,8 +23,8 @@ bool knowrob::semweb::TripleFormatter::exportTo(
 }
 
 bool knowrob::semweb::TripleFormatter::exportRDF_XML(
-        const std::map<std::string_view, TriplePtr> &triples,
-        const std::string &filename) {
+    const std::map<std::string_view, TriplePtr> &triples,
+    const std::string &filename) {
     // make sure the directory exists
     std::filesystem::path path(filename);
     if (path.has_parent_path()) {
@@ -42,13 +42,13 @@ bool knowrob::semweb::TripleFormatter::exportRDF_XML(
     file << "         xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\"\n";
     file << "         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\n";
     // iterate over known namespaces
-    for (const auto &[uri, prefix] : PrefixRegistry::get()) {
+    for (const auto &[uri, prefix]: PrefixRegistry::get()) {
         file << "         xmlns:" << prefix << "=\"" << uri << "\"\n";
     }
     file << ">\n";
 
     // write triples
-    for (const auto &[subject,triple] : triples) {
+    for (const auto &[subject,triple]: triples) {
         file << "  <rdf:Description rdf:about=\"" << subject << "\">\n";
         auto property = triple->predicate();
         auto valueString = triple->createStringValue();

--- a/src/storage/QueryableStorage.cpp
+++ b/src/storage/QueryableStorage.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "knowrob/storage/QueryableStorage.h"
+#include <knowrob/semweb/TripleFormatter.h>
 #include "knowrob/ThreadPool.h"
 #include "knowrob/queries/AnswerNo.h"
 #include "knowrob/queries/AnswerYes.h"
@@ -367,6 +368,26 @@ GraphQueryExpansionPtr QueryableStorage::expand(const GraphQueryPtr &q) {
 	exp_ctx->with_reassignment = supports(StorageFeature::ReAssignment);
 	exp_ctx->expanded = expand_query(q, *exp_ctx);
 	return exp_ctx;
+}
+
+bool QueryableStorage::exportTo(
+		const std::string &filename,
+		semweb::TripleFormat format) const {
+	// collects all triples per subject
+	std::map<std::string_view, TriplePtr> subjectTriples;
+	// iterate over all triples in the storage
+	batch([&](const TripleContainerPtr &container) {
+		for (auto &triple: *container) {
+			// collect triples per subject
+			const auto &[val,_] = subjectTriples.insert(
+					std::make_pair(triple->subject(), triple));
+			// take over the ownership of the triple
+			triple.owned = false;
+			val->second.owned = true;
+		}
+	});
+	// write all triples to the file
+	return semweb::TripleFormatter::exportTo(subjectTriples, filename, format);
 }
 
 namespace knowrob::py {

--- a/tests/StorageTest.cpp
+++ b/tests/StorageTest.cpp
@@ -371,3 +371,8 @@ TYPED_TEST(StorageTest, ExtendsTimeInterval) {
 	statement.setIsOccasional(true);
 	EXPECT_EQ(TEST_LOOKUP(statement).size(), 1);
 }
+
+TYPED_TEST(StorageTest, ExportRDF_XML) {
+	auto &queryable = StorageTest<TypeParam>::queryable_;
+	EXPECT_TRUE(queryable->exportTo("/tmp/knowrob/tests/rdf/test.rdf", semweb::RDF_XML));
+}


### PR DESCRIPTION
This PR adds an interface to `KnowledgeBase` and `QueryableStorage` to export all triples in the model to a file. `RDF/XML` and `Turtle` format are supported for export.